### PR TITLE
feat: switch themes

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -152,4 +152,3 @@ tasks:
         msg: yamllint is not installed
     cmds:
       - yamllint .
-

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,13 +1,12 @@
 ---
 version: '3'
 
+includes:
+  theme: ThemeTasks.yml
+
 vars:
   ALACRITTY_CONFIG_DIR: ~/.config/alacritty
-  ALACRITTY_DARK_THEME: rose-pine
-  ALACRITTY_LIGHT_THEME: rose-pine-dawn
   HELIX_CONFIG_DIR: ~/.config/helix
-  HELIX_DARK_THEME: "rose_pine"
-  HELIX_LIGHT_THEME: "rose_pine_dawn"
   NEOVIM_CONFIG_DIR: ~/.config/nvim
   VIMRC_PATH: ~/.vimrc
   WEZTERM_PATH: ~/.wezterm.lua
@@ -43,7 +42,9 @@ tasks:
     internal: true
     desc: Create a symbolic link to a file
     requires:
-      vars: [SOURCE_FILE, TARGET_FILE]
+      vars:
+        - SOURCE_FILE
+        - TARGET_FILE
     status:
       - "[ -f {{.TARGET_FILE}} ]"
     cmds:
@@ -53,7 +54,9 @@ tasks:
     internal: true
     desc: Create symbolic links to files in a directory
     requires:
-      vars: [SOURCE_DIR, TARGET_DIR]
+      vars:
+        - SOURCE_DIR
+        - TARGET_DIR
     status:
       - "[ -d {{.TARGET_DIR}} ]"
     cmds:
@@ -111,8 +114,8 @@ tasks:
   bootstrap:
     desc: Bootstrap dotfiles
     deps:
-      - install-starship
       - install-omz
+      - install-starship
       - link-alacritty
       - link-helix
       - link-neovim
@@ -150,41 +153,3 @@ tasks:
     cmds:
       - yamllint .
 
-  change-theme:
-    desc: Switch from one theme to another
-    internal: true
-    requires:
-      vars:
-        - NEW
-        - OLD
-        - WHERE
-    cmds:
-      - sed --follow-symlinks -i 's/{{.OLD}}/{{.NEW}}/' {{.WHERE}}
-
-  light:
-    desc: Switch to light theme
-    deps:
-      - task: change-theme
-        vars:
-          NEW: "{{.ALACRITTY_LIGHT_THEME}}.toml"
-          OLD: "{{.ALACRITTY_DARK_THEME}}.toml"
-          WHERE: "{{.ALACRITTY_CONFIG_DIR}}/alacritty.toml"
-      - task: change-theme
-        vars:
-          NEW: "{{.HELIX_LIGHT_THEME}}"
-          OLD: "{{.HELIX_DARK_THEME}}"
-          WHERE: "{{.HELIX_CONFIG_DIR}}/config.toml"
-
-  dark:
-    desc: Switch to dark theme
-    deps:
-      - task: change-theme
-        vars:
-          NEW: "{{.ALACRITTY_DARK_THEME}}.toml"
-          OLD: "{{.ALACRITTY_LIGHT_THEME}}.toml"
-          WHERE: "{{.ALACRITTY_CONFIG_DIR}}/alacritty.toml"
-      - task: change-theme
-        vars:
-          NEW: "{{.HELIX_DARK_THEME}}"
-          OLD: "{{.HELIX_LIGHT_THEME}}"
-          WHERE: "{{.HELIX_CONFIG_DIR}}/config.toml"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -111,6 +111,13 @@ tasks:
           SOURCE_DIR: "{{.USER_WORKING_DIR}}/neovim"
           TARGET_DIR: "{{.NEOVIM_CONFIG_DIR}}"
 
+  link-themes:
+    decs: Create a hardlink to a global task file
+    status:
+      - "[ -f ~/Taskfile.yml ]"
+    cmds:
+      - ln -v {{.USER_WORKING_DIR}}/ThemeTasks.yml ~/Taskfile.yml
+
   bootstrap:
     desc: Bootstrap dotfiles
     deps:
@@ -119,6 +126,7 @@ tasks:
       - link-alacritty
       - link-helix
       - link-neovim
+      - link-themes
       - link-vim
       - link-wezterm
       - link-zsh
@@ -126,6 +134,7 @@ tasks:
   clean-alacritty: rm -rf {{.ALACRITTY_CONFIG_DIR}}
   clean-helix: rm -rf {{.HELIX_CONFIG_DIR}}
   clean-neovim: rm -rf {{.NEOVIM_CONFIG_DIR}}
+  clean-themes: rm -rf ~/Taskfile.yml
   clean-vim: rm -f {{.VIMRC_PATH}}
   clean-wezterm: rm -f {{.WEZTERM_PATH}}
   clean-zsh: rm -f {{.ZSHRC_PATH}}
@@ -136,12 +145,13 @@ tasks:
       Remove Helix, Alacritty and Neovim configuration directories as well as
       .vimrc, .zshrc and wezterm.lua files.
     cmds:
-      - task: clean-vim
-      - task: clean-wezterm
-      - task: clean-zsh
       - task: clean-alacritty
       - task: clean-helix
       - task: clean-neovim
+      - task: clean-themes
+      - task: clean-vim
+      - task: clean-wezterm
+      - task: clean-zsh
 
   lint-yaml:
     desc: Lint YAML files using yamllint

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,11 +3,11 @@ version: '3'
 
 vars:
   ALACRITTY_CONFIG_DIR: ~/.config/alacritty
-  ALACRITTY_LIGHT_THEME: rose-pine-dawn
   ALACRITTY_DARK_THEME: rose-pine
+  ALACRITTY_LIGHT_THEME: rose-pine-dawn
   HELIX_CONFIG_DIR: ~/.config/helix
-  HELIX_LIGHT_THEME: "rose_pine_dawn"
   HELIX_DARK_THEME: "rose_pine"
+  HELIX_LIGHT_THEME: "rose_pine_dawn"
   NEOVIM_CONFIG_DIR: ~/.config/nvim
   VIMRC_PATH: ~/.vimrc
   WEZTERM_PATH: ~/.wezterm.lua
@@ -130,8 +130,8 @@ tasks:
   clean:
     desc: Clean up dotfiles
     summary: >
-      Remove Helix, Alacritty and Neovim configuration directories as well as .vimrc,
-      .zshrc and wezterm.lua files.
+      Remove Helix, Alacritty and Neovim configuration directories as well as
+      .vimrc, .zshrc and wezterm.lua files.
     cmds:
       - task: clean-vim
       - task: clean-wezterm
@@ -150,20 +150,41 @@ tasks:
     cmds:
       - yamllint .
 
+  change-theme:
+    desc: Switch from one theme to another
+    internal: true
+    requires:
+      vars:
+        - NEW
+        - OLD
+        - WHERE
+    cmds:
+      - sed --follow-symlinks -i 's/{{.OLD}}/{{.NEW}}/' {{.WHERE}}
+
   light:
     desc: Switch to light theme
-    silent: true
-    cmds:
-      - sed --follow-symlinks -i 's/{{.ALACRITTY_DARK_THEME}}\.toml/{{.ALACRITTY_LIGHT_THEME}}\.toml/'
-        {{.ALACRITTY_CONFIG_DIR}}/alacritty.toml
-      - sed --follow-symlinks -i 's/"{{.HELIX_DARK_THEME}}"/"{{.HELIX_LIGHT_THEME}}"/'
-        {{.HELIX_CONFIG_DIR}}/config.toml
+    deps:
+      - task: change-theme
+        vars:
+          NEW: "{{.ALACRITTY_LIGHT_THEME}}.toml"
+          OLD: "{{.ALACRITTY_DARK_THEME}}.toml"
+          WHERE: "{{.ALACRITTY_CONFIG_DIR}}/alacritty.toml"
+      - task: change-theme
+        vars:
+          NEW: "{{.HELIX_LIGHT_THEME}}"
+          OLD: "{{.HELIX_DARK_THEME}}"
+          WHERE: "{{.HELIX_CONFIG_DIR}}/config.toml"
 
   dark:
     desc: Switch to dark theme
-    silent: true
-    cmds:
-      - sed --follow-symlinks -i 's/{{.ALACRITTY_LIGHT_THEME}}\.toml/{{.ALACRITTY_DARK_THEME}}\.toml/'
-        {{.ALACRITTY_CONFIG_DIR}}/alacritty.toml
-      - sed --follow-symlinks -i 's/"{{.HELIX_LIGHT_THEME}}"/"{{.HELIX_DARK_THEME}}"/'
-        {{.HELIX_CONFIG_DIR}}/config.toml
+    deps:
+      - task: change-theme
+        vars:
+          NEW: "{{.ALACRITTY_DARK_THEME}}.toml"
+          OLD: "{{.ALACRITTY_LIGHT_THEME}}.toml"
+          WHERE: "{{.ALACRITTY_CONFIG_DIR}}/alacritty.toml"
+      - task: change-theme
+        vars:
+          NEW: "{{.HELIX_DARK_THEME}}"
+          OLD: "{{.HELIX_LIGHT_THEME}}"
+          WHERE: "{{.HELIX_CONFIG_DIR}}/config.toml"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -154,11 +154,16 @@ tasks:
     desc: Switch to light theme
     silent: true
     cmds:
-      - sed -i 's/{{.ALACRITTY_DARK_THEME}}\.toml/{{.ALACRITTY_LIGHT_THEME}}\.toml/'
+      - sed --follow-symlinks -i 's/{{.ALACRITTY_DARK_THEME}}\.toml/{{.ALACRITTY_LIGHT_THEME}}\.toml/'
         {{.ALACRITTY_CONFIG_DIR}}/alacritty.toml
+      - sed --follow-symlinks -i 's/"{{.HELIX_DARK_THEME}}"/"{{.HELIX_LIGHT_THEME}}"/'
+        {{.HELIX_CONFIG_DIR}}/config.toml
+
   dark:
     desc: Switch to dark theme
     silent: true
     cmds:
-      - sed -i 's/{{.ALACRITTY_LIGHT_THEME}}\.toml/{{.ALACRITTY_DARK_THEME}}\.toml/'
+      - sed --follow-symlinks -i 's/{{.ALACRITTY_LIGHT_THEME}}\.toml/{{.ALACRITTY_DARK_THEME}}\.toml/'
         {{.ALACRITTY_CONFIG_DIR}}/alacritty.toml
+      - sed --follow-symlinks -i 's/"{{.HELIX_LIGHT_THEME}}"/"{{.HELIX_DARK_THEME}}"/'
+        {{.HELIX_CONFIG_DIR}}/config.toml

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -64,7 +64,6 @@ tasks:
       - ln -sv {{.SOURCE_DIR}}/* {{.TARGET_DIR}}
 
   link-zsh:
-    desc: Create symbolic link to .zshrc
     cmds:
       - task: link-file
         vars:
@@ -72,7 +71,6 @@ tasks:
           TARGET_FILE: "{{.ZSHRC_PATH}}"
 
   link-alacritty:
-    desc: Create symbolic links to Alacritty configuration
     cmds:
       - task: link-dir
         vars:
@@ -80,7 +78,6 @@ tasks:
           TARGET_DIR: "{{.ALACRITTY_CONFIG_DIR}}"
 
   link-wezterm:
-    desc: Create a symbolic link to wezterm.lua
     cmds:
       - task: link-file
         vars:
@@ -88,7 +85,6 @@ tasks:
           TARGET_FILE: "{{.WEZTERM_PATH}}"
 
   link-helix:
-    desc: Create symbolic links to Helix configuration
     cmds:
       - task: link-dir
         vars:
@@ -96,7 +92,6 @@ tasks:
           TARGET_DIR: "{{.HELIX_CONFIG_DIR}}"
 
   link-vim:
-    desc: Create a symbolic link to .vimrc
     cmds:
       - task: link-file
         vars:
@@ -104,7 +99,6 @@ tasks:
           TARGET_FILE: "{{.VIMRC_PATH}}"
 
   link-neovim:
-    desc: Create symbolic links to Neovim configuration
     cmds:
       - task: link-dir
         vars:
@@ -112,7 +106,10 @@ tasks:
           TARGET_DIR: "{{.NEOVIM_CONFIG_DIR}}"
 
   link-themes:
-    decs: Create a hardlink to a global task file
+    summary: >
+      Hardlink theme tasks as a global taskfile to be able to execute them from
+      anywhere. Hardlink is required because Task does not treat symlinks as
+      taskfiles.
     status:
       - "[ -f ~/Taskfile.yml ]"
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,7 +3,11 @@ version: '3'
 
 vars:
   ALACRITTY_CONFIG_DIR: ~/.config/alacritty
+  ALACRITTY_LIGHT_THEME: rose-pine-dawn
+  ALACRITTY_DARK_THEME: rose-pine
   HELIX_CONFIG_DIR: ~/.config/helix
+  HELIX_LIGHT_THEME: "rose_pine_dawn"
+  HELIX_DARK_THEME: "rose_pine"
   NEOVIM_CONFIG_DIR: ~/.config/nvim
   VIMRC_PATH: ~/.vimrc
   WEZTERM_PATH: ~/.wezterm.lua
@@ -126,8 +130,8 @@ tasks:
   clean:
     desc: Clean up dotfiles
     summary: >
-      Remove Helix, Alacritty and Neovim configuration directories as well as
-      .vimrc, .zshrc and wezterm.lua files.
+      Remove Helix, Alacritty and Neovim configuration directories as well as .vimrc,
+      .zshrc and wezterm.lua files.
     cmds:
       - task: clean-vim
       - task: clean-wezterm
@@ -145,3 +149,16 @@ tasks:
         msg: yamllint is not installed
     cmds:
       - yamllint .
+
+  light:
+    desc: Switch to light theme
+    silent: true
+    cmds:
+      - sed -i 's/{{.ALACRITTY_DARK_THEME}}\.toml/{{.ALACRITTY_LIGHT_THEME}}\.toml/'
+        {{.ALACRITTY_CONFIG_DIR}}/alacritty.toml
+  dark:
+    desc: Switch to dark theme
+    silent: true
+    cmds:
+      - sed -i 's/{{.ALACRITTY_LIGHT_THEME}}\.toml/{{.ALACRITTY_DARK_THEME}}\.toml/'
+        {{.ALACRITTY_CONFIG_DIR}}/alacritty.toml

--- a/ThemeTasks.yml
+++ b/ThemeTasks.yml
@@ -27,6 +27,11 @@ tasks:
     deps:
       - task: change-theme
         vars:
+          NEW: "{{.ALACRITTY_LIGHT_THEME}}.yml"
+          OLD: "{{.ALACRITTY_DARK_THEME}}.yml"
+          WHERE: "{{.ALACRITTY_CONFIG_DIR}}/alacritty.yml"
+      - task: change-theme
+        vars:
           NEW: "{{.ALACRITTY_LIGHT_THEME}}.toml"
           OLD: "{{.ALACRITTY_DARK_THEME}}.toml"
           WHERE: "{{.ALACRITTY_CONFIG_DIR}}/alacritty.toml"
@@ -39,6 +44,11 @@ tasks:
   dark:
     desc: Switch to dark theme
     deps:
+      - task: change-theme
+        vars:
+          NEW: "{{.ALACRITTY_DARK_THEME}}.yml"
+          OLD: "{{.ALACRITTY_LIGHT_THEME}}.yml"
+          WHERE: "{{.ALACRITTY_CONFIG_DIR}}/alacritty.yml"
       - task: change-theme
         vars:
           NEW: "{{.ALACRITTY_DARK_THEME}}.toml"

--- a/ThemeTasks.yml
+++ b/ThemeTasks.yml
@@ -1,0 +1,50 @@
+---
+version: '3'
+
+vars:
+  ALACRITTY_CONFIG_DIR: ~/.config/alacritty
+  ALACRITTY_DARK_THEME: rose-pine
+  ALACRITTY_LIGHT_THEME: rose-pine-dawn
+  HELIX_CONFIG_DIR: ~/.config/helix
+  HELIX_DARK_THEME: "rose_pine"
+  HELIX_LIGHT_THEME: "rose_pine_dawn"
+
+tasks:
+  change-theme:
+    desc: Switch from one theme to another
+    internal: true
+    requires:
+      vars:
+        - NEW
+        - OLD
+        - WHERE
+    cmds:
+      - sed --follow-symlinks -i 's/{{.OLD}}/{{.NEW}}/' {{.WHERE}}
+
+  light:
+    desc: Switch to light theme
+    deps:
+      - task: change-theme
+        vars:
+          NEW: "{{.ALACRITTY_LIGHT_THEME}}.toml"
+          OLD: "{{.ALACRITTY_DARK_THEME}}.toml"
+          WHERE: "{{.ALACRITTY_CONFIG_DIR}}/alacritty.toml"
+      - task: change-theme
+        vars:
+          NEW: "{{.HELIX_LIGHT_THEME}}"
+          OLD: "{{.HELIX_DARK_THEME}}"
+          WHERE: "{{.HELIX_CONFIG_DIR}}/config.toml"
+
+  dark:
+    desc: Switch to dark theme
+    deps:
+      - task: change-theme
+        vars:
+          NEW: "{{.ALACRITTY_DARK_THEME}}.toml"
+          OLD: "{{.ALACRITTY_LIGHT_THEME}}.toml"
+          WHERE: "{{.ALACRITTY_CONFIG_DIR}}/alacritty.toml"
+      - task: change-theme
+        vars:
+          NEW: "{{.HELIX_DARK_THEME}}"
+          OLD: "{{.HELIX_LIGHT_THEME}}"
+          WHERE: "{{.HELIX_CONFIG_DIR}}/config.toml"

--- a/ThemeTasks.yml
+++ b/ThemeTasks.yml
@@ -6,12 +6,12 @@ vars:
   ALACRITTY_DARK_THEME: rose-pine
   ALACRITTY_LIGHT_THEME: rose-pine-dawn
   HELIX_CONFIG_DIR: ~/.config/helix
-  HELIX_DARK_THEME: "rose_pine"
-  HELIX_LIGHT_THEME: "rose_pine_dawn"
+  HELIX_DARK_THEME: rose_pine
+  HELIX_LIGHT_THEME: rose_pine_dawn
 
 tasks:
   change-theme:
-    desc: Switch from one theme to another
+    desc: Switch from one theme to another.
     internal: true
     silent: true
     requires:
@@ -23,7 +23,7 @@ tasks:
       - sed --follow-symlinks -i 's/{{.OLD}}/{{.NEW}}/' {{.WHERE}}
 
   light:
-    desc: Switch to light theme
+    desc: Switch to light theme.
     deps:
       - task: change-theme
         vars:
@@ -42,7 +42,7 @@ tasks:
           WHERE: "{{.HELIX_CONFIG_DIR}}/config.toml"
 
   dark:
-    desc: Switch to dark theme
+    desc: Switch to dark theme.
     deps:
       - task: change-theme
         vars:

--- a/ThemeTasks.yml
+++ b/ThemeTasks.yml
@@ -13,6 +13,7 @@ tasks:
   change-theme:
     desc: Switch from one theme to another
     internal: true
+    silent: true
     requires:
       vars:
         - NEW

--- a/ThemeTasks.yml
+++ b/ThemeTasks.yml
@@ -37,8 +37,8 @@ tasks:
           WHERE: "{{.ALACRITTY_CONFIG_DIR}}/alacritty.toml"
       - task: change-theme
         vars:
-          NEW: "{{.HELIX_LIGHT_THEME}}"
-          OLD: "{{.HELIX_DARK_THEME}}"
+          NEW: "\"{{.HELIX_LIGHT_THEME}}\""
+          OLD: "\"{{.HELIX_DARK_THEME}}\""
           WHERE: "{{.HELIX_CONFIG_DIR}}/config.toml"
 
   dark:
@@ -56,6 +56,6 @@ tasks:
           WHERE: "{{.ALACRITTY_CONFIG_DIR}}/alacritty.toml"
       - task: change-theme
         vars:
-          NEW: "{{.HELIX_DARK_THEME}}"
-          OLD: "{{.HELIX_LIGHT_THEME}}"
+          NEW: "\"{{.HELIX_DARK_THEME}}\""
+          OLD: "\"{{.HELIX_LIGHT_THEME}}\""
           WHERE: "{{.HELIX_CONFIG_DIR}}/config.toml"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -116,4 +116,7 @@ export BAT_THEME="base16"
 # Example aliases
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
+alias li="task -g light"
+alias da="task -g dark"
+
 eval "$(starship init zsh)"


### PR DESCRIPTION
Create tasks that switch between selected light and dark themes in Alacritty and Helix configuration files using sed.

Extract these tasks in a separate taskfile and make it global.

Add `li` and `da` aliases to Zsh configuration to quickly switch to light and dark theme respectively.

Closes: #19 