### PR TITLE
feat(vim): add fzf integration

### DIFF
--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -168,6 +168,7 @@ if isdirectory(".git")
 	set path+=**
 endif
 
+" If fzf is available use its built-in Vim plugin for file navigation
 if executable("fzf")
 	set rtp+=/opt/homebrew/opt/fzf
 	set rtp+=~/.fzf

--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -167,3 +167,9 @@ endif
 if isdirectory(".git")
 	set path+=**
 endif
+
+if executable("fzf")
+	set rtp+=/opt/homebrew/opt/fzf
+	set rtp+=~/.fzf
+	nnoremap <leader>f :FZF<CR>
+endif


### PR DESCRIPTION
If `fzf` executable is available add its directory to the runtime path and use its built-in Vim plugin to fuzzy search files.

Closes: #41