### PR TITLE
fix(vim): YAML formatting

### DIFF
--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -161,7 +161,7 @@ if executable("shfmt")
 endif
 
 if executable("yamlfmt")
-	autocmd FileType yaml setlocal formatprg=yamlfmt\ -formatter\ include_document_start=true\ -formatter\ retain_line_breaks=true\ -in
+	autocmd FileType yaml setlocal formatprg=yamlfmt\ -formatter\ retain_line_breaks=true\ -in
 endif
 
 if isdirectory(".git")


### PR DESCRIPTION
Do not add document start because formatprg could be used on a hunk of code in a middle of a document.