### PR TITLE
fix(vim): E492: Not an editor command: FZF

### DIFF
--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -171,6 +171,7 @@ endif
 " If fzf is available use its built-in Vim plugin for file navigation
 if executable("fzf")
 	set rtp+=/opt/homebrew/opt/fzf  " for macOS and fzf installed via brew
+	set rtp+=/usr/share/doc/fzf/examples  " for Debian and fzf installed via apt
 	" NOTE(kirillmorozov): fzf.vim might not exist in the runtimepath so I
 	" explicitly read Ex commands from the plugin and check FZF command
 	" existance before adding a key map.

--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -170,9 +170,14 @@ endif
 
 " If fzf is available use its built-in Vim plugin for file navigation
 if executable("fzf")
-	set rtp+=/opt/homebrew/opt/fzf
-	set rtp+=~/.fzf
-	nnoremap <leader>f :FZF<CR>
+	set rtp+=/opt/homebrew/opt/fzf  " for macOS and fzf installed via brew
+	" NOTE(kirillmorozov): fzf.vim might not exist in the runtimepath so I
+	" explicitly read Ex commands from the plugin and check FZF command
+	" existance before adding a key map.
+	runtime plugin/fzf.vim
+	if exists(':FZF') == 2
+		nnoremap <leader>f :FZF<CR>
+	endif
 endif
 
 " Set up Git TUI client

--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -174,7 +174,7 @@ if executable("fzf")
 	set rtp+=/usr/share/doc/fzf/examples  " for Debian and fzf installed via apt
 	" NOTE(kirillmorozov): fzf.vim might not exist in the runtimepath so I
 	" explicitly read Ex commands from the plugin and check FZF command
-	" existance before adding a key map.
+	" existence before adding a key map.
 	runtime plugin/fzf.vim
 	if exists(':FZF') == 2
 		nnoremap <leader>f :FZF<CR>


### PR DESCRIPTION
Explicitly read Ex commands from the fzf.vim plugin and check `FZF` command existence before adding a key map to avoid an issue when fzf is located in the path, the plugin is absent from the runtime path but the keymap is set anyway.