### PR TITLE
feat(alacritty): use nerd font

### DIFF
--- a/alacritty/alacritty.toml
+++ b/alacritty/alacritty.toml
@@ -1,7 +1,7 @@
 import = ["~/.config/alacritty/rose-pine.toml"]
 
 [font]
-size = 12.0
+size = 14.0
 
 [font.normal]
-family = "Fira Code"
+family = "FiraCode Nerd Font"


### PR DESCRIPTION
Use Nerd Font patched Fira Code as Alacritty's font to properly render icons and increase font size to 14 for better experience on a MacBook.