### PR TITLE
fix(vim): colorscheme not available

### DIFF
--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -48,7 +48,7 @@ if has("termguicolors")
 	set termguicolors
 	try
 		colorscheme zaibatsu
-	catch
+	catch /E185:/
 		" NOTE(kirillmorozov): zaibatsu may not be available on older vim
 		" versions, fall back to habamax instead.
 		colorscheme habamax

--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -44,10 +44,17 @@ syntax enable
 
 filetype plugin indent on
 
-colorscheme default
 if has("termguicolors")
 	set termguicolors
-	colorscheme zaibatsu
+	try
+		colorscheme zaibatsu
+	catch
+		" NOTE(kirillmorozov): zaibatsu may not be available on older vim
+		" versions, fall back to habamax instead.
+		colorscheme habamax
+	endtry
+else
+	colorscheme default
 endif
 
 " Show tabs, multiple consecutive spaces, trailing spaces and breaks


### PR DESCRIPTION
On LMDE 6 an error `E185: Cannot find colour scheme 'zaibatsu'` is displayed when loading Vim because it's an old version that does not have such colour scheme available.

This catches such error an falls back to `habamax` colour scheme.