### PR TITLE
feat(task): install completions

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -46,7 +46,10 @@ tasks:
   completions:fd:
     desc: Install fd completions.
     cmds:
-      - fd --gen-completions=zsh > {{.COMPLETIONS_PATH}}/_fd
+      - cmd: fd --gen-completions=zsh > {{.COMPLETIONS_PATH}}/_fd
+        ignore_error: true
+      - cmd: fdfind --gen-completions=zsh > {{.COMPLETIONS_PATH}}/_fd
+        ignore_error: true
 
   completions:ripgrep:
     desc: Install ripgrep completions.
@@ -56,7 +59,8 @@ tasks:
   completions:task:
     desc: Install task completions.
     cmds:
-      - task --completion zsh 2> {{.COMPLETIONS_PATH}}/_task
+      - cmd: task --completion zsh 2> {{.COMPLETIONS_PATH}}/_task
+        ignore_error: true
 
   completions:
     desc: Install completions for most used tools.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -27,6 +27,14 @@ tasks:
     cmds:
       - brew install starship
 
+  install:completions:
+    desc: Generate completions for most used tools.
+    vars:
+      COMPLETION_PATH: ~/.oh-my-zsh/custom/completions
+    cmds:
+        - rg --generate=complete-zsh > {{.COMPLETION_PATH}}/_rg
+        - task --completion zsh 2> {{.COMPLETION_PATH}}/_task
+
   install:omz:
     desc: Install Oh My Zsh.
     status:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,6 +6,7 @@ includes:
 
 vars:
   ALACRITTY_CONFIG_DIR: ~/.config/alacritty
+  COMPLETIONS_PATH: ~/.oh-my-zsh/custom/completions
   GLOBAL_TASK_FILE: ~/Taskfile.yml
   HELIX_CONFIG_DIR: ~/.config/helix
   NEOVIM_CONFIG_DIR: ~/.config/nvim
@@ -35,17 +36,37 @@ tasks:
       # yamllint disable-line rule:line-length
       - sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 
+  install:completions:brew:
+    desc: Install brew completions.
+    platforms:
+      - darwin
+    cmds:
+      - brew completions link
+
+  install:completions:fd:
+    desc: Install fd completions.
+    cmds:
+      - fd --gen-completions=zsh > {{.COMPLETIONS_PATH}}/_fd
+
+  install:completions:ripgrep:
+    desc: Install ripgrep completions.
+    cmds:
+      - rg --generate=complete-zsh > {{.COMPLETIONS_PATH}}/_rg
+
+  install:completions:task:
+    desc: Install task completions.
+    cmds:
+      - task --completion zsh 2> {{.COMPLETIONS_PATH}}/_task
+
   install:completions:
-    desc: Generate completions for most used tools.
-    vars:
-      COMPLETION_PATH: ~/.oh-my-zsh/custom/completions
+    desc: Install completions for most used tools.
     deps:
       - install:omz
     cmds:
-      - brew completions link
-      - fd --gen-completions=zsh > {{.COMPLETION_PATH}}/_fd
-      - rg --generate=complete-zsh > {{.COMPLETION_PATH}}/_rg
-      - task --completion zsh 2> {{.COMPLETION_PATH}}/_task
+      - task: install:completions:brew
+      - task: install:completions:fd
+      - task: install:completions:ripgrep
+      - task: install:completions:task
 
   stow:package:
     internal: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -27,16 +27,6 @@ tasks:
     cmds:
       - brew install starship
 
-  install:completions:
-    desc: Generate completions for most used tools.
-    vars:
-      COMPLETION_PATH: ~/.oh-my-zsh/custom/completions
-    cmds:
-      - brew completions link
-      - fd --gen-completions=zsh > {{.COMPLETION_PATH}}/_fd
-      - rg --generate=complete-zsh > {{.COMPLETION_PATH}}/_rg
-      - task --completion zsh 2> {{.COMPLETION_PATH}}/_task
-
   install:omz:
     desc: Install Oh My Zsh.
     status:
@@ -44,6 +34,18 @@ tasks:
     cmds:
       # yamllint disable-line rule:line-length
       - sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+
+  install:completions:
+    desc: Generate completions for most used tools.
+    vars:
+      COMPLETION_PATH: ~/.oh-my-zsh/custom/completions
+    deps:
+      - install:omz
+    cmds:
+      - brew completions link
+      - fd --gen-completions=zsh > {{.COMPLETION_PATH}}/_fd
+      - rg --generate=complete-zsh > {{.COMPLETION_PATH}}/_rg
+      - task --completion zsh 2> {{.COMPLETION_PATH}}/_task
 
   stow:package:
     internal: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -71,6 +71,7 @@ tasks:
     deps:
       - install:omz
     cmds:
+      - mkdir -p {{.COMPLETIONS_PATH}}
       - task: completions:brew
       - task: completions:fd
       - task: completions:ripgrep

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -33,6 +33,7 @@ tasks:
       COMPLETION_PATH: ~/.oh-my-zsh/custom/completions
     cmds:
       - brew completions link
+      - fd --gen-completions=zsh > {{.COMPLETION_PATH}}/_fd
       - rg --generate=complete-zsh > {{.COMPLETION_PATH}}/_rg
       - task --completion zsh 2> {{.COMPLETION_PATH}}/_task
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -32,6 +32,7 @@ tasks:
     vars:
       COMPLETION_PATH: ~/.oh-my-zsh/custom/completions
     cmds:
+      - brew completions link
       - rg --generate=complete-zsh > {{.COMPLETION_PATH}}/_rg
       - task --completion zsh 2> {{.COMPLETION_PATH}}/_task
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -46,6 +46,8 @@ tasks:
   completions:fd:
     desc: Install fd completions.
     cmds:
+      # NOTE(kirillmorozov): fd might be installed under different names on
+      # different OSes so try them all and ignore errors in the process.
       - cmd: fd --gen-completions=zsh > {{.COMPLETIONS_PATH}}/_fd
         ignore_error: true
       - cmd: fdfind --gen-completions=zsh > {{.COMPLETIONS_PATH}}/_fd
@@ -60,6 +62,8 @@ tasks:
     desc: Install task completions.
     cmds:
       - cmd: task --completion zsh 2> {{.COMPLETIONS_PATH}}/_task
+        # NOTE(kirillmorozov): Task version that comes with Ubuntu 24.04 does
+        # not have --completions flag.
         ignore_error: true
 
   completions:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -36,37 +36,37 @@ tasks:
       # yamllint disable-line rule:line-length
       - sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 
-  install:completions:brew:
+  completions:brew:
     desc: Install brew completions.
     platforms:
       - darwin
     cmds:
       - brew completions link
 
-  install:completions:fd:
+  completions:fd:
     desc: Install fd completions.
     cmds:
       - fd --gen-completions=zsh > {{.COMPLETIONS_PATH}}/_fd
 
-  install:completions:ripgrep:
+  completions:ripgrep:
     desc: Install ripgrep completions.
     cmds:
       - rg --generate=complete-zsh > {{.COMPLETIONS_PATH}}/_rg
 
-  install:completions:task:
+  completions:task:
     desc: Install task completions.
     cmds:
       - task --completion zsh 2> {{.COMPLETIONS_PATH}}/_task
 
-  install:completions:
+  completions:
     desc: Install completions for most used tools.
     deps:
       - install:omz
     cmds:
-      - task: install:completions:brew
-      - task: install:completions:fd
-      - task: install:completions:ripgrep
-      - task: install:completions:task
+      - task: completions:brew
+      - task: completions:fd
+      - task: completions:ripgrep
+      - task: completions:task
 
   stow:package:
     internal: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -32,8 +32,8 @@ tasks:
     vars:
       COMPLETION_PATH: ~/.oh-my-zsh/custom/completions
     cmds:
-        - rg --generate=complete-zsh > {{.COMPLETION_PATH}}/_rg
-        - task --completion zsh 2> {{.COMPLETION_PATH}}/_task
+      - rg --generate=complete-zsh > {{.COMPLETION_PATH}}/_rg
+      - task --completion zsh 2> {{.COMPLETION_PATH}}/_task
 
   install:omz:
     desc: Install Oh My Zsh.

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -77,7 +77,6 @@ plugins=(
   dnf
   docker
   docker-compose
-  fd
   fzf
   gh
   git

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -86,7 +86,6 @@ plugins=(
   helm
   kubectl
   python
-  ripgrep
   terraform
   ubuntu
   vscode


### PR DESCRIPTION
Install completions for `ripgrep` and `fd` manually since Oh My Zsh no longer provides plugins for those utilities.

Also install completions for brew and task.

Related-to: ohmyzsh/ohmyzsh#12576