### PR TITLE
feat(zsh): alias `fd` on Ubuntu

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -116,6 +116,9 @@ fi
 # Example aliases
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
+if command -v fdfind &> /dev/null; then
+	alias fd="fdfind"
+fi
 if command -v go-task &> /dev/null; then
 	alias task="go-task"
 fi


### PR DESCRIPTION
On Ubuntu `fd` executable is called `fdfind`. This adds an `fd` alias to `fdfind` for uniform experience across distributions.