### PR TITLE
fix(ansible): ensure `~/.local/bin` exists

### DIFF
--- a/roles/install-packages/tasks/install-starship.yml
+++ b/roles/install-packages/tasks/install-starship.yml
@@ -3,11 +3,16 @@
   register: starship_executable
   ansible.builtin.stat:
     path: "{{ local_bin_dir }}/starship"
-- name: Download install script
+- name: Download Starship installation script
   when: not starship_executable.stat.exists
   ansible.builtin.get_url:
     dest: /tmp/install-starship.sh
     url: https://starship.rs/install.sh
+- name: Create installation directory
+  when: not starship_executable.stat.exists
+  ansible.builtin.file:
+    path: "{{ local_bin_dir }}"
+    state: directory
 - name: Run Starship installation script
   when: not starship_executable.stat.exists
   ansible.builtin.script:


### PR DESCRIPTION
Before proceeding with Starship installation ensure that directory that binary will be installed into exists.