### PR TITLE
fix(vim): shell scripts indentation

### DIFF
--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -133,6 +133,8 @@ autocmd BufNewFile,BufRead,BufReadPost Jenkinsfile setfiletype groovy
 " YAML indentation
 autocmd FileType yaml setlocal tabstop=2 softtabstop=2 shiftwidth=2 expandtab
 
+autocmd FileType sh setlocal tabstop=2 softtabstop=2 shiftwidth=2 expandtab
+
 " Key mappings
 " Search
 nmap <Esc> :nohlsearch<CR>


### PR DESCRIPTION
Configure shell scripts indentation to match [Google's Shell Style Guide][shellguide].

[shellguide]: https://google.github.io/styleguide/shellguide.html