### PR TITLE
feat(vim): unset unnamedplus clipboard

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -177,7 +177,7 @@ nmap [b :bprevious<CR>
 nmap ]B :blast<CR>
 nmap ]b :bnext<CR>
 " Clipboard
-vmap <leader>y "+y
+map <leader>y "+y
 map <leader>p "+p
 map <leader><s-p> "+<s-p>
 

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -182,12 +182,18 @@ map <leader>p "+p
 map <leader><s-p> "+<s-p>
 
 if isdirectory(".git")
-	set path+=**
+    set path+=**
 endif
 
 " Use ripgrep for search if it's installed
 if executable("rg")
-    set grepprg=rg\ --vimgrep\ --smart-case\ --follow\ --hidden\ --glob\ '!.git/**'
+    set grepprg=rg
+                \\ --vimgrep
+                \\ --smart-case
+                \\ --follow
+                \\ --hidden
+                \\ --glob
+                \\ '!.git/**'
 endif
 
 " If fzf is available use its built-in Vim plugin for file navigation

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -124,9 +124,6 @@ set sidescrolloff=8
 " Command-line completion operates in an enhanced mode
 set wildmenu
 
-" Use system clipboard
-set clipboard^=unnamed,unnamedplus
-
 " Key mappings
 " Search
 nmap <Esc> :nohlsearch<CR>

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -176,6 +176,10 @@ nmap [B :brewind<CR>
 nmap [b :bprevious<CR>
 nmap ]B :blast<CR>
 nmap ]b :bnext<CR>
+" Clipboard
+vmap <leader>y "+y
+map <leader>p "+p
+map <leader><s-p> "+<s-p>
 
 if isdirectory(".git")
 	set path+=**


### PR DESCRIPTION
Remove `unnamed` and `unnamedplus` options from clipboard and add explicit key maps to copy and paste into/from the plus register.