### PR TITLE
feat(vim): autoformat files

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -215,7 +215,26 @@ if executable("lazygit")
         execute "silent !lazygit"
         redraw!
     endfunction
-    command G :call Git()
-    command Git :call Git()
-    nmap <C-G> :Git<CR>
+    nmap <c-g> :call Git()<cr>
 endif
+
+function! s:Format(...)
+    silent keepjumps normal! '[v']gq
+    if v:shell_error > 0
+        silent undo
+        echohl ErrorMsg
+        echomsg 'formatprg "' . &formatprg . '" exited with status ' . v:shell_error
+        echohl None
+    endif
+endfunction
+
+function! s:FormatFile() abort
+    let w:view = winsaveview()
+    keepjumps normal! gg
+    set operatorfunc=<SID>Format
+    keepjumps normal! g@G
+    keepjumps call winrestview(w:view)
+    unlet w:view
+endfunction
+
+command Fmt :call <sid>FormatFile()<cr>

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -229,6 +229,10 @@ function! s:Format(...)
 endfunction
 
 function! s:FormatFile() abort
+    if &l:formatprg==""
+        echomsg 'formatprg is not set for the this buffer'
+        return
+    endif
     let w:view = winsaveview()
     keepjumps normal! gg
     set operatorfunc=<SID>Format
@@ -238,3 +242,8 @@ function! s:FormatFile() abort
 endfunction
 
 command Fmt :call <sid>FormatFile()
+
+augroup Autoformat
+    autocmd!
+    autocmd BufWritePre * call <sid>FormatFile()
+augroup END

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -237,4 +237,4 @@ function! s:FormatFile() abort
     unlet w:view
 endfunction
 
-command Fmt :call <sid>FormatFile()<cr>
+command Fmt :call <sid>FormatFile()


### PR DESCRIPTION
Add a function (inspired by [this blog post][code-formatting-vim]) that formats the whole file and a `Fmt` command to call this function as well as an auto command to run this function before writing the buffer.

[code-formatting-vim]: https://phelipetls.github.io/posts/code-formatting-vim/