### PR TITLE
feat(vim): update `formatprg` for YAML

### DIFF
--- a/vim/ftplugin/yaml.vim
+++ b/vim/ftplugin/yaml.vim
@@ -5,7 +5,20 @@ setlocal softtabstop=2
 setlocal tabstop=2
 
 if executable("yamlfmt")
-    setlocal formatprg=yamlfmt\ -formatter\ retain_line_breaks=true\ -in
+    setlocal formatprg=yamlfmt
+                \\ -formatter
+                \\ include_document_start=true
+                \\ -formatter
+                \\ max_line_length=80
+                \\ -formatter
+                \\ pad_line_comments=2
+                \\ -formatter
+                \\ retain_line_breaks=true
+                \\ -formatter
+                \\ retain_line_breaks_single=true
+                \\ -formatter
+                \\ scan_folded_as_literal=true
+                \\ -in
 elseif executable("yq")
     setlocal formatprg=yq\ '.'
 endif

--- a/vim/ftplugin/yaml.vim
+++ b/vim/ftplugin/yaml.vim
@@ -7,8 +7,6 @@ setlocal tabstop=2
 if executable("yamlfmt")
     setlocal formatprg=yamlfmt
                 \\ -formatter
-                \\ include_document_start=true
-                \\ -formatter
                 \\ max_line_length=80
                 \\ -formatter
                 \\ pad_line_comments=2


### PR DESCRIPTION
Limit the line length to 80, pad comments with 2 spaces, retain only a single line break and scan folded strings as literals.