### PR TITLE
feat(wezterm): switch theme back to Rosé Pine

### DIFF
--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -15,9 +15,9 @@ end
 --- Returns prefered theme for appearance.
 local function scheme_for_appearance(appearance)
 	if appearance:find("Dark") then
-		return "rose-pine"
+		return "Rosé Pine (Gogh)"
 	else
-		return "rose-pine-dawn"
+		return "Rosé Pine Dawn (Gogh)"
 	end
 end
 


### PR DESCRIPTION
`rose-pine` is not good at showing text that's currently selected.