### PR TITLE
feat(vim): remove gleam ftplugin

### DIFF
--- a/vim/ftplugin/gleam.vim
+++ b/vim/ftplugin/gleam.vim
@@ -1,1 +1,0 @@
-setlocal formatprg=gleam\ format\ --stdin


### PR DESCRIPTION
It's not required since vim/vim@3cbd7f18e320aa1df652c9a16bed4b284c4538b8.