### PR TITLE
feat(vim): change colorscheme to wildcharm

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -47,9 +47,9 @@ filetype plugin indent on
 if has("termguicolors")
     set termguicolors
     try
-        colorscheme zaibatsu
+        colorscheme wildcharm
     catch /E185:/
-        " NOTE(kirillmorozov): zaibatsu may not be available on older vim
+        " NOTE(kirillmorozov): wildcharm may not be available on older vim
         " versions, fall back to habamax instead.
         colorscheme habamax
     endtry


### PR DESCRIPTION
Use wildcharm as the default colour scheme because it supports both light and dark backgrounds.