### PR TITLE
feat(vim): enable built-in packages

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -126,7 +126,6 @@ set wildmenu
 
 " Key mappings
 " Search
-nmap <Esc> :nohlsearch<CR>
 nmap <leader>/ :grep<Space>
 nnoremap N Nzz
 nnoremap n nzz
@@ -247,3 +246,10 @@ augroup Autoformat
     autocmd!
     autocmd BufWritePre * call <sid>FormatFile()
 augroup END
+
+" Built-in packages
+packadd comment
+packadd hlyank
+packadd nohlsearch
+
+let g:hlyank_duration = 150

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -247,9 +247,10 @@ augroup Autoformat
     autocmd BufWritePre * call <sid>FormatFile()
 augroup END
 
-" Built-in packages
+" Enable built-in packages
 packadd comment
 packadd hlyank
 packadd nohlsearch
 
+" Packages configuration
 let g:hlyank_duration = 150


### PR DESCRIPTION
Enable `comment`, `hlyank` and `nohlsearch` packages.