### PR TITLE
refactor(vim): configuration

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -46,13 +46,14 @@ filetype plugin indent on
 
 if has("termguicolors")
     set termguicolors
-    try
-        colorscheme wildcharm
-    catch /E185:/
-        " NOTE(kirillmorozov): wildcharm may not be available on older vim
-        " versions, fall back to habamax instead.
-        colorscheme habamax
-    endtry
+    for s:cs in ["wildcharm", "zaibatsu", "habamax", "default"]
+        try
+            execute 'colorscheme ' . s:cs
+            break
+        catch /E185:/
+            " colorscheme not found, try next
+        endtry
+    endfor
 else
     colorscheme default
 endif
@@ -250,5 +251,3 @@ augroup END
 silent! packadd comment
 silent! packadd hlyank | let g:hlyank_duration = 150
 silent! packadd nohlsearch
-
-" Packages configuration

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -215,34 +215,35 @@ if executable("lazygit")
     nmap <c-g> :call Git()<cr>
 endif
 
-function! s:Format(...)
-    silent keepjumps normal! '[v']gq
+" Autoformat
+function! s:FormatRange(first, last) abort
+  if empty(&l:formatprg)
+    echohl WarningMsg | echomsg 'formatprg is not set for this buffer' | echohl None
+    return
+  endif
+  let l:view = winsaveview()
+  try
+    silent keepjumps keepmarks keeppatterns execute a:first . ',' . a:last . 'normal! gq'
     if v:shell_error > 0
-        silent undo
-        echohl ErrorMsg
-        echomsg 'formatprg "' . &formatprg . '" exited with status ' . v:shell_error
-        echohl None
+      silent undo
+      echoerr 'formatprg "' . &l:formatprg . '" exited with status ' . v:shell_error
+    else
+      silent! undojoin
     endif
+  finally
+    call winrestview(l:view)
+  endtry
 endfunction
 
-function! s:FormatFile() abort
-    if &l:formatprg==""
-        echomsg 'formatprg is not set for the this buffer'
-        return
-    endif
-    let w:view = winsaveview()
-    keepjumps normal! gg
-    set operatorfunc=<SID>Format
-    keepjumps normal! g@G
-    keepjumps call winrestview(w:view)
-    unlet w:view
+function! s:OpFormat(type, ...) abort
+  call s:FormatRange(line("'["), line("']"))
 endfunction
 
-command Fmt :call <sid>FormatFile()
+command! -range=% -bar Fmt call s:FormatRange(<line1>, <line2>)
 
 augroup Autoformat
-    autocmd!
-    autocmd BufWritePre * call <sid>FormatFile()
+  autocmd!
+  autocmd BufWritePre * silent! Fmt
 augroup END
 
 " Enable built-in packages

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -247,9 +247,8 @@ augroup Autoformat
 augroup END
 
 " Enable built-in packages
-packadd comment
-packadd hlyank
-packadd nohlsearch
+silent! packadd comment
+silent! packadd hlyank | let g:hlyank_duration = 150
+silent! packadd nohlsearch
 
 " Packages configuration
-let g:hlyank_duration = 150

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -216,35 +216,34 @@ if executable("lazygit")
     nmap <c-g> :call Git()<cr>
 endif
 
-" Autoformat
-function! s:FormatRange(first, last) abort
-  if empty(&l:formatprg)
-    echohl WarningMsg | echomsg 'formatprg is not set for this buffer' | echohl None
-    return
-  endif
-  let l:view = winsaveview()
-  try
-    silent keepjumps keepmarks keeppatterns execute a:first . ',' . a:last . 'normal! gq'
+function! s:Format(...)
+    silent keepjumps normal! '[v']gq
     if v:shell_error > 0
-      silent undo
-      echoerr 'formatprg "' . &l:formatprg . '" exited with status ' . v:shell_error
-    else
-      silent! undojoin
+        silent undo
+        echohl ErrorMsg
+        echomsg 'formatprg "' . &formatprg . '" exited with status ' . v:shell_error
+        echohl None
     endif
-  finally
-    call winrestview(l:view)
-  endtry
 endfunction
 
-function! s:OpFormat(type, ...) abort
-  call s:FormatRange(line("'["), line("']"))
+function! s:FormatFile() abort
+    if &l:formatprg==""
+        echomsg 'formatprg is not set for the this buffer'
+        return
+    endif
+    let w:view = winsaveview()
+    keepjumps normal! gg
+    set operatorfunc=<SID>Format
+    keepjumps normal! g@G
+    keepjumps call winrestview(w:view)
+    unlet w:view
 endfunction
 
-command! -range=% -bar Fmt call s:FormatRange(<line1>, <line2>)
+command Fmt :call <sid>FormatFile()
 
 augroup Autoformat
-  autocmd!
-  autocmd BufWritePre * silent! Fmt
+    autocmd!
+    autocmd BufWritePre * call <sid>FormatFile()
 augroup END
 
 " Enable built-in packages


### PR DESCRIPTION
Loop over color schemes to apply the first one that's available.

Suppress an error when trying to source optional plugins on a machine that does not have these packages.