### PR TITLE
feat(vim): find files using `fd`

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -213,7 +213,7 @@ function! s:FdFindFunc(cmdarg, cmdcomplete)
                 \ --follow
                 \ --full-path
                 \ --hidden
-                \ --type file "
+                \ --type file"
     let fd_output = systemlist(find_command)
     if v:shell_error
         echoerr fd_output

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -213,13 +213,13 @@ function! s:FdFindFunc(cmdarg, cmdcomplete)
                 \ --follow
                 \ --full-path
                 \ --hidden
-                \ --type file " .. a:cmdarg
+                \ --type file "
     let fd_output = systemlist(find_command)
     if v:shell_error
         echoerr fd_output
         return []
     endif
-    return fd_output
+    return fd_output->matchfuzzy(a:cmdarg)
 endfunction
 
 " Use fd to find files if it's available

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -207,6 +207,20 @@ if executable("rg")
                 \\ '!.git/**'
 endif
 
+func! s:FdFindFunc(cmdarg, cmdcomplete)
+    let result = systemlist("fd --full-path --hidden --follow --exclude .git " .. a:cmdarg)
+    if v:shell_error != 0
+        echoerr result
+        return []
+    endif
+    return result
+endfunc
+
+" Use fd to find files if it's available
+if executable("fd")
+    set findfunc=s:FdFindFunc
+endif
+
 " Set up Git TUI client
 if executable("lazygit")
     function Git()

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -207,14 +207,14 @@ if executable("rg")
                 \\ '!.git/**'
 endif
 
-func! s:FdFindFunc(cmdarg, cmdcomplete)
-    let result = systemlist("fd --full-path --hidden --follow --exclude .git " .. a:cmdarg)
+function! s:FdFindFunc(cmdarg, cmdcomplete)
+    let result = systemlist("fd --type file --full-path --hidden --follow --exclude .git " .. a:cmdarg)
     if v:shell_error != 0
         echoerr result
         return []
     endif
     return result
-endfunc
+endfunction
 
 " Use fd to find files if it's available
 if executable("fd")

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -208,12 +208,18 @@ if executable("rg")
 endif
 
 function! s:FdFindFunc(cmdarg, cmdcomplete)
-    let result = systemlist("fd --type file --full-path --hidden --follow --exclude .git " .. a:cmdarg)
-    if v:shell_error != 0
-        echoerr result
+    let find_command = "fd
+                \ --exclude .git
+                \ --follow
+                \ --full-path
+                \ --hidden
+                \ --type file " .. a:cmdarg
+    let fd_output = systemlist(find_command)
+    if v:shell_error
+        echoerr fd_output
         return []
     endif
-    return result
+    return fd_output
 endfunction
 
 " Use fd to find files if it's available


### PR DESCRIPTION
If `fd` is available configure `findfunc` to find all files using `fd` and then fuzzy match the filename using Vim's built-in `matchfuzzy()` function.

Closes: #169