### PR TITLE
feat(vim): open found file in a vertical split

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -214,7 +214,7 @@ function! s:VertSplitFind() abort
 	let l:line = getcmdline()
 	if l:line =~# '^\s*\%(vert\s\+\)\?find\>'
 		let l:new = substitute(l:line, '^\s*\%(vert\s\+\)\?find\>', 'vert sfind', '')
-		return "\<C-U>" . l:new
+		return "\<C-U>" . l:new . "\<CR>"
 	endif
 	return "\<C-v>"
 endfunction

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -134,11 +134,26 @@ set wildignore+=*.pyc,*/.git/*,*/node_modules/*
 nmap <leader>/ :grep<Space>
 nnoremap N Nzz
 nnoremap n nzz
+function! s:ToggleFindVert() abort
+	if getcmdtype() != ':'
+		return "\<C-v>"
+	endif
+	let l:line = getcmdline()
+	if l:line =~# '^\s*vert\s\+find\>'
+		let l:new = substitute(l:line, '^\s*vert\s\+', '', '')
+	elseif l:line =~# '^\s*find\>'
+		let l:new = 'vert ' . substitute(l:line, '^\s*', '', '')
+	else
+		return "\<C-v>"
+	endif
+	return "\<C-U>" . l:new
+endfunction
+cnoremap <expr> <C-v> <SID>ToggleFindVert()
 " General navigation
 nnoremap <Leader>b :buffers<CR>:buffer<Space>
 nnoremap <C-S> :update<CR>
 nnoremap <leader>f :find<Space>
-nnoremap <leader>h :help<Space>
+nnoremap <leader>h :vert<Space>help<Space>
 " Window navigation
 nmap <leader>w <c-w>
 nmap <C-H> <c-w>h

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -134,21 +134,6 @@ set wildignore+=*.pyc,*/.git/*,*/node_modules/*
 nmap <leader>/ :grep<Space>
 nnoremap N Nzz
 nnoremap n nzz
-function! s:ToggleFindVert() abort
-	if getcmdtype() != ':'
-		return "\<C-v>"
-	endif
-	let l:line = getcmdline()
-	if l:line =~# '^\s*vert\s\+find\>'
-		let l:new = substitute(l:line, '^\s*vert\s\+', '', '')
-	elseif l:line =~# '^\s*find\>'
-		let l:new = 'vert ' . substitute(l:line, '^\s*', '', '')
-	else
-		return "\<C-v>"
-	endif
-	return "\<C-U>" . l:new
-endfunction
-cnoremap <expr> <C-v> <SID>ToggleFindVert()
 " General navigation
 nnoremap <Leader>b :buffers<CR>:buffer<Space>
 nnoremap <C-S> :update<CR>
@@ -208,6 +193,8 @@ map <leader>p "+p
 map <leader><s-p> "+<s-p>
 " Make
 nmap <Leader>m :make<Space>
+" Open file in a vertical split
+cnoremap <expr> <C-v> <SID>VertSplitFind()
 
 " Use ripgrep for search if it's installed
 if executable('rg')
@@ -219,6 +206,18 @@ if executable('rg')
 				\\ --glob
 				\\ '!.git/**'
 endif
+
+function! s:VertSplitFind() abort
+	if getcmdtype() != ':'
+		return "\<C-v>"
+	endif
+	let l:line = getcmdline()
+	if l:line =~# '^\s*\%(vert\s\+\)\?find\>'
+		let l:new = substitute(l:line, '^\s*\%(vert\s\+\)\?find\>', 'vert sfind', '')
+		return "\<C-U>" . l:new
+	endif
+	return "\<C-v>"
+endfunction
 
 " Initialise files cache.
 let s:filescache = []


### PR DESCRIPTION
Add `<C-v>` key map to command-line to open `find` command result in a vertical split.