### PR TITLE
fix(vim): buffers switching

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -135,7 +135,7 @@ nmap <leader>/ :grep<Space>
 nnoremap N Nzz
 nnoremap n nzz
 " General navigation
-nnoremap <Leader>b :buffers<CR>:buffer<Space>
+nnoremap <Leader>b :buffer<Space>
 nnoremap <C-S> :update<CR>
 nnoremap <leader>f :find<Space>
 nnoremap <leader>h :vert<Space>help<Space>


### PR DESCRIPTION
Do not call `:buffers` on `<Leader>b` key map because wild trigger will preview all possible options anyway.