### PR TITLE
feat(ansible): add tags

### DIFF
--- a/roles/development-machine/tasks/change-shell.yml
+++ b/roles/development-machine/tasks/change-shell.yml
@@ -1,7 +1,7 @@
 ---
 - name: Set Zsh as user shell
   become: true
-  when: ansible_system == "Linux"
+  when: ansible_facts["system"] == "Linux"
   ansible.builtin.user:
     name: "{{ ansible_user_id }}"
     shell: /usr/bin/zsh

--- a/roles/development-machine/tasks/install-completions.yml
+++ b/roles/development-machine/tasks/install-completions.yml
@@ -1,7 +1,7 @@
 ---
 - name: Link brew completions
   ansible.builtin.command: brew completions link
-  when: ansible_distribution == "MacOSX"
+  when: ansible_facts["distribution"] == "MacOSX"
 - name: Include variables
   ansible.builtin.include_vars:
     file: config-links.yml

--- a/roles/development-machine/tasks/install-nerd-font.yml
+++ b/roles/development-machine/tasks/install-nerd-font.yml
@@ -2,12 +2,12 @@
 - name: "Check {{ font.name_prefix }}*.ttf existance"
   register: font_files
   ansible.builtin.find:
-    paths: "{{ dest_per_system[ansible_system] }}"
+    paths: "{{ dest_per_system[ansible_facts['system']] }}"
     patterns: "{{ font.name_prefix }}*.ttf"
 - name: "Unarchive {{ font.archive }}"
   when: not font_files.matched
   ansible.builtin.unarchive:
     dest: "{{ dest_per_system[ansible_system] }}"
     remote_src: true
-    src: "https://github.com/ryanoasis/nerd-fonts/releases/download/\
-      {{ version }}/{{ font.archive }}"
+    src: "https://github.com/ryanoasis/nerd-fonts/releases/download/{{ version }}/{{
+      font.archive }}"

--- a/roles/development-machine/tasks/install-nerd-font.yml
+++ b/roles/development-machine/tasks/install-nerd-font.yml
@@ -9,5 +9,6 @@
   ansible.builtin.unarchive:
     dest: "{{ dest_per_system[ansible_system] }}"
     remote_src: true
-    src: "https://github.com/ryanoasis/nerd-fonts/releases/download/{{ version }}/{{
-      font.archive }}"
+    src: >-
+      https://github.com/ryanoasis/nerd-fonts/releases/download/{{ version
+      }}/{{ font.archive }}

--- a/roles/development-machine/tasks/install-nerd-fonts.yml
+++ b/roles/development-machine/tasks/install-nerd-fonts.yml
@@ -4,7 +4,7 @@
     file: fonts.yml
 - name: Fonts directory exists
   ansible.builtin.file:
-    path: "{{ dest_per_system[ansible_system] }}"
+    path: "{{ dest_per_system[ansible_facts['system']] }}"
     state: directory
 - name: Install Nerd Fonts
   ansible.builtin.include_tasks:

--- a/roles/development-machine/tasks/install-nerd-fonts.yml
+++ b/roles/development-machine/tasks/install-nerd-fonts.yml
@@ -12,10 +12,8 @@
     apply:
       tags:
         - fonts
-        - nerd_fonts
   loop: "{{ fonts }}"
   loop_control:
     loop_var: font
   tags:
     - fonts
-    - nerd_fonts

--- a/roles/development-machine/tasks/install-nerd-fonts.yml
+++ b/roles/development-machine/tasks/install-nerd-fonts.yml
@@ -7,7 +7,15 @@
     path: "{{ dest_per_system[ansible_system] }}"
     state: directory
 - name: Install Nerd Fonts
-  ansible.builtin.include_tasks: install-nerd-font.yml
+  ansible.builtin.include_tasks:
+    file: install-nerd-font.yml
+    apply:
+      tags:
+        - fonts
+        - nerd_fonts
   loop: "{{ fonts }}"
   loop_control:
     loop_var: font
+  tags:
+    - fonts
+    - nerd_fonts

--- a/roles/development-machine/tasks/install-packages.yml
+++ b/roles/development-machine/tasks/install-packages.yml
@@ -6,7 +6,7 @@
       tags:
         - packages
         - macos
-  when: ansible_distribution == "MacOSX"
+  when: ansible_facts["distribution"] == "MacOSX"
   tags:
     - packages
     - macos
@@ -19,7 +19,7 @@
         - linux
         - deb
         - linux_mint
-  when: ansible_distribution == "Linux Mint"
+  when: ansible_facts["distribution"] == "Linux Mint"
   tags:
     - packages
     - linux
@@ -34,7 +34,7 @@
         - linux
         - rpm
         - fedora
-  when: ansible_distribution == "Fedora"
+  when: ansible_facts["distribution"] == "Fedora"
   tags:
     - packages
     - linux
@@ -47,7 +47,7 @@
       tags:
         - packages
         - starship
-  when: ansible_system == "Linux"
+  when: ansible_facts["system"] == "Linux"
   tags:
     - packages
     - starship

--- a/roles/development-machine/tasks/install-packages.yml
+++ b/roles/development-machine/tasks/install-packages.yml
@@ -1,15 +1,65 @@
 ---
 - name: Install macOS packages
-  ansible.builtin.include_tasks: install-macos-packages.yml
+  ansible.builtin.include_tasks:
+    file: install-macos-packages.yml
+    apply:
+      tags:
+        - packages
+        - macos
   when: ansible_distribution == "MacOSX"
+  tags:
+    - packages
+    - macos
 - name: Install deb packages
-  ansible.builtin.include_tasks: install-deb-packages.yml
+  ansible.builtin.include_tasks:
+    file: install-deb-packages.yml
+    apply:
+      tags:
+        - packages
+        - linux
+        - deb
+        - linux_mint
   when: ansible_distribution == "Linux Mint"
+  tags:
+    - packages
+    - linux
+    - deb
+    - linux_mint
 - name: Install rpm packages
-  ansible.builtin.include_tasks: install-rpm-packages.yml
+  ansible.builtin.include_tasks:
+    file: install-rpm-packages.yml
+    apply:
+      tags:
+        - packages
+        - linux
+        - rpm
+        - fedora
   when: ansible_distribution == "Fedora"
+  tags:
+    - packages
+    - linux
+    - rpm
+    - fedora
 - name: Install Starship
-  ansible.builtin.include_tasks: install-starship.yml
+  ansible.builtin.include_tasks:
+    file: install-starship.yml
+    apply:
+      tags:
+        - packages
+        - starship
   when: ansible_system == "Linux"
+  tags:
+    - packages
+    - starship
 - name: Install Oh My Zsh
-  ansible.builtin.include_tasks: install-ohmyzsh.yml
+  ansible.builtin.include_tasks:
+    file: install-ohmyzsh.yml
+    apply:
+      tags:
+        - packages
+        - zsh
+        - ohmyzsh
+  tags:
+    - packages
+    - zsh
+    - ohmyzsh

--- a/roles/development-machine/tasks/link-configs.yml
+++ b/roles/development-machine/tasks/link-configs.yml
@@ -8,7 +8,6 @@
     apply:
       tags:
         - configs
-        - stow
   loop: "{{ directory_mapping }}"
   loop_control:
     loop_var: app_config
@@ -17,4 +16,3 @@
     target_dir: "{{ app_config.target }}"
   tags:
     - configs
-    - stow

--- a/roles/development-machine/tasks/link-configs.yml
+++ b/roles/development-machine/tasks/link-configs.yml
@@ -3,10 +3,18 @@
   ansible.builtin.include_vars:
     file: config-links.yml
 - name: Stow config files
-  ansible.builtin.include_tasks: stow.yml
+  ansible.builtin.include_tasks:
+    file: stow.yml
+    apply:
+      tags:
+        - configs
+        - stow
   loop: "{{ directory_mapping }}"
   loop_control:
     loop_var: app_config
   vars:
     src_dir: "{{ app_config.source }}"
     target_dir: "{{ app_config.target }}"
+  tags:
+    - configs
+    - stow

--- a/roles/development-machine/tasks/main.yml
+++ b/roles/development-machine/tasks/main.yml
@@ -1,11 +1,21 @@
 ---
 - name: Install packages
   ansible.builtin.import_tasks: install-packages.yml
+  tags:
+    - packages
 - name: Install completions
   ansible.builtin.import_tasks: install-completions.yml
+  tags:
+    - completions
 - name: Install fonts
   ansible.builtin.import_tasks: install-nerd-fonts.yml
+  tags:
+    - fonts
 - name: Link configs
   ansible.builtin.import_tasks: link-configs.yml
+  tags:
+    - configs
 - name: Change shell
   ansible.builtin.import_tasks: change-shell.yml
+  tags:
+    - shell


### PR DESCRIPTION
Add per-task tags and apply.tags blocks across package/config/font installers plus corresponding tags on `main.yml`, to improve play targeting and to make `ansible-playbook … --tags` workflows far more granular.