### PR TITLE
fix(vim): refresh file cache on every command-line entry

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -322,7 +322,7 @@ augroup cmdline_autocomplete
 		autocmd CmdlineChanged [:\/\?] call wildtrigger()
 	endif
 	" Empty files cache on cmdline entry
-	autocmd CmdlineEnter :find let s:filescache = []
+	autocmd CmdlineEnter : let s:filescache = []
 augroup END
 
 " Enable built-in packages


### PR DESCRIPTION
The `CmdlineEnter` pattern matches against command-line type, not the command text. Using `:find` as pattern didn't work, so newly created files weren't appearing in `:find` completions until Vim was restarted.