### PR TITLE
feat(vim): add `<Leader>'` to resume last command

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -155,7 +155,7 @@ nnoremap n nzz
 nnoremap <Leader>b :buffer<Space>
 nnoremap <C-S> :update<CR>
 nnoremap <leader>f :find<Space>
-nnoremap <silent> <Leader>' :call <SID>ResumeFindCmd()<CR>
+nnoremap <silent> <Leader>' :call <SID>ResumeLastCmd()<CR>
 nnoremap <leader>h :vert<Space>help<Space>
 " Window navigation
 nnoremap <C-D> <C-D>zz
@@ -245,8 +245,6 @@ endfunction
 
 " Initialise files cache.
 let s:filescache = []
-" Store the last :find query for resuming
-let s:lastfind = ''
 
 " Get a list of all files using built-in globpath.
 function! s:GlobFiles() abort
@@ -292,9 +290,9 @@ if exists('+findfunc')
 	set findfunc=s:FindFunc
 endif
 
-" Re-open :find command pre-filled with last query
-function! s:ResumeFindCmd() abort
-	call feedkeys(':find ' . s:lastfind, 'tn')
+" Re-open last command pre-filled for editing
+function! s:ResumeLastCmd() abort
+	call feedkeys(':' . histget(':', -1), 'tn')
 endfunction
 
 " Set up Git TUI client
@@ -336,10 +334,6 @@ augroup cmdline_autocomplete
 	endif
 	" Empty files cache on cmdline entry
 	autocmd CmdlineEnter : let s:filescache = []
-	" Save last :find query before leaving (getcmdline() is still set on <Esc>)
-	autocmd CmdlineLeavePre : if getcmdline() =~# '^\s*find\>' |
-				\ let s:lastfind = substitute(getcmdline(), '^\s*find\s*', '', '') |
-				\ endif
 augroup END
 
 " Enable built-in packages

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -155,6 +155,7 @@ nnoremap n nzz
 nnoremap <Leader>b :buffer<Space>
 nnoremap <C-S> :update<CR>
 nnoremap <leader>f :find<Space>
+nnoremap <silent> <Leader>' :call <SID>ResumeFindCmd()<CR>
 nnoremap <leader>h :vert<Space>help<Space>
 " Window navigation
 nnoremap <C-D> <C-D>zz
@@ -244,6 +245,8 @@ endfunction
 
 " Initialise files cache.
 let s:filescache = []
+" Store the last :find query for resuming
+let s:lastfind = ''
 
 " Get a list of all files using built-in globpath.
 function! s:GlobFiles() abort
@@ -289,6 +292,11 @@ if exists('+findfunc')
 	set findfunc=s:FindFunc
 endif
 
+" Re-open :find command pre-filled with last query
+function! s:ResumeFindCmd() abort
+	call feedkeys(':find ' . s:lastfind, 'tn')
+endfunction
+
 " Set up Git TUI client
 if executable('lazygit')
 	function! Git()
@@ -328,6 +336,10 @@ augroup cmdline_autocomplete
 	endif
 	" Empty files cache on cmdline entry
 	autocmd CmdlineEnter : let s:filescache = []
+	" Save last :find query as user types
+	autocmd CmdlineChanged : if getcmdline() =~# '^\s*find\>' |
+				\ let s:lastfind = substitute(getcmdline(), '^\s*find\s*', '', '') |
+				\ endif
 augroup END
 
 " Enable built-in packages

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -292,7 +292,7 @@ endif
 
 " Re-open last command pre-filled for editing
 function! s:ResumeLastCmd() abort
-	call feedkeys(':' . histget(':', -1), 'tn')
+	call feedkeys(':' . histget(':'), 'tn')
 endfunction
 
 " Set up Git TUI client

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -336,8 +336,8 @@ augroup cmdline_autocomplete
 	endif
 	" Empty files cache on cmdline entry
 	autocmd CmdlineEnter : let s:filescache = []
-	" Save last :find query as user types
-	autocmd CmdlineChanged : if getcmdline() =~# '^\s*find\>' |
+	" Save last :find query before leaving (getcmdline() is still set on <Esc>)
+	autocmd CmdlineLeavePre : if getcmdline() =~# '^\s*find\>' |
 				\ let s:lastfind = substitute(getcmdline(), '^\s*find\s*', '', '') |
 				\ endif
 augroup END


### PR DESCRIPTION
Mirror the fzf-lua resume keybinding from the Neovim config. Pressing
`<Leader>'` opens the command line pre-filled with the last ex command
for editing or re-execution.