### PR TITLE
feat(vim): visual search mappings

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -151,6 +151,7 @@ endif
 nnoremap <leader>/ :grep<Space>
 nnoremap N Nzz
 nnoremap n nzz
+xnoremap <silent> <Leader>/ y:<C-U>execute 'grep! -F ' . shellescape(@")<CR>
 " General navigation
 nnoremap <Leader>b :buffer<Space>
 nnoremap <C-S> :update<CR>

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -215,6 +215,8 @@ noremap <leader><s-p> "+<s-p>
 nnoremap <Leader>m :make<Space>
 " Open file in a vertical split
 cnoremap <expr> <C-v> <SID>VertSplitFind()
+" Search for visually selected text
+vnoremap * y/\V<C-r>=escape(@",'/\')<CR><CR>
 
 " Use ripgrep for search if it's installed
 if executable('rg')

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -148,9 +148,10 @@ endif
 
 " Key mappings
 " Search
-nnoremap <leader>/ :grep<Space>
+nnoremap <Leader>/ :grep<Space>
 nnoremap N Nzz
 nnoremap n nzz
+xnoremap * y/\V<C-r>=escape(@",'/\')<CR><CR>
 xnoremap <silent> <Leader>/ y:<C-U>execute 'grep! -F ' . shellescape(@")<CR>
 " General navigation
 nnoremap <Leader>b :buffer<Space>
@@ -216,8 +217,6 @@ noremap <leader><s-p> "+<s-p>
 nnoremap <Leader>m :make<Space>
 " Open file in a vertical split
 cnoremap <expr> <C-v> <SID>VertSplitFind()
-" Search for visually selected text
-vnoremap * y/\V<C-r>=escape(@",'/\')<CR><CR>
 
 " Use ripgrep for search if it's installed
 if executable('rg')


### PR DESCRIPTION
Add visual-mode search mappings so selected text can be searched directly with `*` or `<Leader>/`.

This improves search workflow by removing manual pattern entry and keeps quickfix population non-disruptive via `grep!`.