### PR TITLE
feat(neovim): add visual search mappings

### DIFF
--- a/neovim/lua/plugins/fzf.lua
+++ b/neovim/lua/plugins/fzf.lua
@@ -50,6 +50,15 @@ return {
 				desc = "Search for a string and get results live",
 			},
 			{
+				"<Leader>/",
+				function()
+					vim.cmd('noautocmd normal! "vy')
+					require("fzf-lua").live_grep({ query = vim.fn.getreg("v") })
+				end,
+				mode = "x",
+				desc = "Search for visual selection with live grep",
+			},
+			{
 				"<Leader>?",
 				"<cmd>FzfLua commands<cr>",
 				desc = "List available commands",

--- a/neovim/plugin/keymaps.lua
+++ b/neovim/plugin/keymaps.lua
@@ -4,6 +4,15 @@ vim.keymap.set("n", "<leader>cc", vim.cmd.cclose, { desc = "Close quickfix list"
 vim.keymap.set("n", "<leader>co", vim.cmd.copen, { desc = "Open quickfix list" })
 vim.keymap.set("n", "N", "Nzz", { desc = "Center screen when searching" })
 vim.keymap.set("n", "n", "nzz", { desc = "Center screen when searching" })
+vim.keymap.set(
+	"x",
+	"*",
+	[[y/\V<C-r>=escape(@",'/\')<CR><CR>]],
+	{ desc = "Search for visual selection" }
+)
+vim.keymap.set("x", "<leader>/", function()
+	vim.cmd("execute 'grep! -F ' . shellescape(@\")")
+end, { silent = true, desc = "Grep for visual selection" })
 
 -- Plus register yank/paste
 vim.keymap.set(

--- a/neovim/plugin/keymaps.lua
+++ b/neovim/plugin/keymaps.lua
@@ -10,7 +10,7 @@ vim.keymap.set(
 	[[y/\V<C-r>=escape(@",'/\')<CR><CR>]],
 	{ desc = "Search for visual selection" }
 )
-vim.keymap.set("x", "<leader>/", function()
+vim.keymap.set("x", "<Leader>/", function()
 	vim.cmd("execute 'grep! -F ' . shellescape(@\")")
 end, { silent = true, desc = "Grep for visual selection" })
 


### PR DESCRIPTION
Add visual-mode search mappings so selected text can be searched directly without manual pattern entry.

`*` searches the buffer for the selection using `\V` (literal match). `<Leader>/` opens fzf-lua `live_grep` with the selection pre-filled; falls back to quickfix via `grep!` when fzf-lua is unavailable.
