### PR TITLE
feat(ansible): add GitLab CLI package

### DIFF
--- a/roles/development_machine/tasks/install-macos-packages.yml
+++ b/roles/development_machine/tasks/install-macos-packages.yml
@@ -6,6 +6,7 @@
       - btop
       - fd
       - fzf
+      - glab
       - go-task
       - helix
       - jq

--- a/roles/development_machine/tasks/install-rpm-packages.yml
+++ b/roles/development_machine/tasks/install-rpm-packages.yml
@@ -63,6 +63,7 @@
       - fzf
       - gh
       - git
+      - glab
       - go-task
       - golang
       - gopls


### PR DESCRIPTION
Add the `glab` CLI tool to the list of packages installed on both macOS and RPM-based development machines.