### PR TITLE
refactor(vim): clean up config and improve compatibility

### DIFF
--- a/vim/ftplugin/python.vim
+++ b/vim/ftplugin/python.vim
@@ -1,5 +1,4 @@
 compiler ruff
-nnoremap <buffer> <Leader>m :make<Space>%<CR>
 setlocal autoindent
 setlocal colorcolumn=80
 setlocal expandtab

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -298,11 +298,11 @@ endfunction
 
 " Set up Git TUI client
 if executable('lazygit')
-	function! Git()
+	function! s:Git()
 		execute 'silent !lazygit'
 		redraw!
 	endfunction
-	nmap <c-g> :call Git()<cr>
+	nnoremap <c-g> :call <SID>Git()<cr>
 endif
 
 function! s:FormatFile() abort

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -27,9 +27,6 @@ let g:netrw_altv=1
 " Tree style view in netrw
 let g:netrw_liststyle=3
 
-" Make Vim behave in a more useful way
-set nocompatible
-
 " Do not use a swapfile for the buffer
 set noswapfile
 

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -287,6 +287,8 @@ endfunction
 " Set findfunc but only if it's supported.
 if exists('+findfunc')
 	set findfunc=s:FindFunc
+else
+	set path+=**
 endif
 
 " Re-open last command pre-filled for editing


### PR DESCRIPTION
Remove set nocompatible, which Vim sets automatically when loading a user vimrc. Add a `path+=**` fallback so `:find` works recursively on Vim versions before 9.1 that lack `findfunc` support.

Scope `Git()` as script-local and replace `nmap` with `nnoremap` for consistency with the rest of the config. Remove the buffer-local `<Leader>m` override from the Python ftplugin so make behaviour is uniform across filetypes.