### PR TITLE
fix(ansible): stuck playbook on Fedora

### DIFF
--- a/roles/development_machine/tasks/install-rpm-packages.yml
+++ b/roles/development_machine/tasks/install-rpm-packages.yml
@@ -14,7 +14,7 @@
     name: wezfurlong/wezterm-nightly
 - name: Fedora bloat uninstalled
   become: true
-  ansible.builtin.dnf:
+  ansible.builtin.dnf5:
     state: absent
     pkg:
       - akregator
@@ -54,7 +54,7 @@
       - neochat
 - name: Fedora packages installed
   become: true
-  ansible.builtin.dnf:
+  ansible.builtin.dnf5:
     state: present
     pkg:
       - alacritty

--- a/roles/development_machine/tasks/install-rpm-packages.yml
+++ b/roles/development_machine/tasks/install-rpm-packages.yml
@@ -4,8 +4,7 @@
   ansible.builtin.yum_repository:
     baseurl: https://cli.github.com/packages/rpm
     description: GitHub CLI
-    gpgkey: >-
-      https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x23F3D4EA75716059
+    gpgkey: https://cli.github.com/packages/githubcli-archive-keyring.gpg
     name: gh-cli
     state: present
 - name: Enable Wezterm Copr


### PR DESCRIPTION
Update Fedora RPM tasks to use `ansible.builtin.dnf5` instead of `ansible.builtin.dnf`, matching Fedora 43's package manager behaviour.

Also replace the GitHub CLI repository GPG keyserver lookup URL with GitHub's direct archive key URL to avoid keyserver-related stalls during repository setup.