### PR TITLE
feat(wezterm): add tmux-style pane keybindings

### DIFF
--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -36,6 +36,33 @@ config.font_size = 14.0
 config.max_fps = 120
 config.window_padding = { bottom = 0, left = 0, right = 0, top = 0 }
 
+-- Leader key (tmux-style prefix)
+config.leader = { key = "a", mods = "CTRL", timeout_milliseconds = 1000 }
+
+config.keys = {
+	-- Split panes (tmux defaults: " for horizontal, % for vertical)
+	{ key = '"', mods = "LEADER", action = wezterm.action.SplitVertical({ domain = "CurrentPaneDomain" }) },
+	{ key = "%", mods = "LEADER", action = wezterm.action.SplitHorizontal({ domain = "CurrentPaneDomain" }) },
+
+	-- Navigate panes (vim-style, popular tmux plugin: vim-tmux-navigator)
+	{ key = "h", mods = "LEADER", action = wezterm.action.ActivatePaneDirection("Left") },
+	{ key = "j", mods = "LEADER", action = wezterm.action.ActivatePaneDirection("Down") },
+	{ key = "k", mods = "LEADER", action = wezterm.action.ActivatePaneDirection("Up") },
+	{ key = "l", mods = "LEADER", action = wezterm.action.ActivatePaneDirection("Right") },
+
+	-- Resize panes
+	{ key = "H", mods = "LEADER", action = wezterm.action.AdjustPaneSize({ "Left", 5 }) },
+	{ key = "J", mods = "LEADER", action = wezterm.action.AdjustPaneSize({ "Down", 5 }) },
+	{ key = "K", mods = "LEADER", action = wezterm.action.AdjustPaneSize({ "Up", 5 }) },
+	{ key = "L", mods = "LEADER", action = wezterm.action.AdjustPaneSize({ "Right", 5 }) },
+
+	-- Zoom pane (tmux: prefix + z)
+	{ key = "z", mods = "LEADER", action = wezterm.action.TogglePaneZoomState },
+
+	-- Close pane (tmux: prefix + x)
+	{ key = "x", mods = "LEADER", action = wezterm.action.CloseCurrentPane({ confirm = true }) },
+}
+
 wezterm.plugin
 	.require("https://github.com/adriankarlen/bar.wezterm")
 	.apply_to_config(config, {

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -41,26 +41,62 @@ config.leader = { key = "Space", mods = "CTRL", timeout_milliseconds = 1000 }
 
 config.keys = {
 	-- Split panes (tmux defaults: " for horizontal, % for vertical)
-	{ key = '"', mods = "LEADER", action = wezterm.action.SplitVertical({ domain = "CurrentPaneDomain" }) },
-	{ key = "%", mods = "LEADER", action = wezterm.action.SplitHorizontal({ domain = "CurrentPaneDomain" }) },
+	{
+		key = '"',
+		mods = "LEADER",
+		action = wezterm.action.SplitVertical({ domain = "CurrentPaneDomain" }),
+	},
+	{
+		key = "%",
+		mods = "LEADER",
+		action = wezterm.action.SplitHorizontal({ domain = "CurrentPaneDomain" }),
+	},
 
 	-- Navigate panes (vim-style, popular tmux plugin: vim-tmux-navigator)
-	{ key = "h", mods = "LEADER", action = wezterm.action.ActivatePaneDirection("Left") },
-	{ key = "j", mods = "LEADER", action = wezterm.action.ActivatePaneDirection("Down") },
+	{
+		key = "h",
+		mods = "LEADER",
+		action = wezterm.action.ActivatePaneDirection("Left"),
+	},
+	{
+		key = "j",
+		mods = "LEADER",
+		action = wezterm.action.ActivatePaneDirection("Down"),
+	},
 	{ key = "k", mods = "LEADER", action = wezterm.action.ActivatePaneDirection("Up") },
-	{ key = "l", mods = "LEADER", action = wezterm.action.ActivatePaneDirection("Right") },
+	{
+		key = "l",
+		mods = "LEADER",
+		action = wezterm.action.ActivatePaneDirection("Right"),
+	},
 
 	-- Resize panes
-	{ key = "H", mods = "LEADER", action = wezterm.action.AdjustPaneSize({ "Left", 5 }) },
-	{ key = "J", mods = "LEADER", action = wezterm.action.AdjustPaneSize({ "Down", 5 }) },
+	{
+		key = "H",
+		mods = "LEADER",
+		action = wezterm.action.AdjustPaneSize({ "Left", 5 }),
+	},
+	{
+		key = "J",
+		mods = "LEADER",
+		action = wezterm.action.AdjustPaneSize({ "Down", 5 }),
+	},
 	{ key = "K", mods = "LEADER", action = wezterm.action.AdjustPaneSize({ "Up", 5 }) },
-	{ key = "L", mods = "LEADER", action = wezterm.action.AdjustPaneSize({ "Right", 5 }) },
+	{
+		key = "L",
+		mods = "LEADER",
+		action = wezterm.action.AdjustPaneSize({ "Right", 5 }),
+	},
 
 	-- Zoom pane (tmux: prefix + z)
 	{ key = "z", mods = "LEADER", action = wezterm.action.TogglePaneZoomState },
 
 	-- Close pane (tmux: prefix + x)
-	{ key = "x", mods = "LEADER", action = wezterm.action.CloseCurrentPane({ confirm = true }) },
+	{
+		key = "x",
+		mods = "LEADER",
+		action = wezterm.action.CloseCurrentPane({ confirm = true }),
+	},
 }
 
 wezterm.plugin

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -37,7 +37,7 @@ config.max_fps = 120
 config.window_padding = { bottom = 0, left = 0, right = 0, top = 0 }
 
 -- Leader key (tmux-style prefix)
-config.leader = { key = "a", mods = "CTRL", timeout_milliseconds = 1000 }
+config.leader = { key = "Space", mods = "CTRL", timeout_milliseconds = 1000 }
 
 config.keys = {
 	-- Split panes (tmux defaults: " for horizontal, % for vertical)

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -33,8 +33,7 @@ config.max_fps = 120
 config.window_padding = { bottom = 0, left = 0, right = 0, top = 0 }
 
 -- Leader key (tmux-style prefix)
-config.leader = { key = "Space", mods = "CTRL", timeout_milliseconds = 1000 }
-
+config.leader = { key = "b", mods = "CTRL", timeout_milliseconds = 1000 }
 config.keys = {
 	-- Split panes (tmux defaults: " for horizontal, % for vertical)
 	{

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -21,17 +21,13 @@ local function scheme_for_appearance(appearance)
 	end
 end
 
-local color_scheme_name = scheme_for_appearance(get_appearance())
-local color_scheme = wezterm.color.get_builtin_schemes()[color_scheme_name]
-local font = wezterm.font_with_fallback({ "FiraCode Nerd Font", "Fira Code" })
-
 local config = wezterm.config_builder()
 config:set_strict_mode(true)
 
 config.animation_fps = 120
-config.color_scheme = color_scheme_name
+config.color_scheme = scheme_for_appearance(get_appearance())
 config.enable_scroll_bar = false
-config.font = font
+config.font = wezterm.font_with_fallback({ "FiraCode Nerd Font", "Fira Code" })
 config.font_size = 14.0
 config.max_fps = 120
 config.window_padding = { bottom = 0, left = 0, right = 0, top = 0 }


### PR DESCRIPTION
Enables WezTerm as a terminal multiplexer without needing tmux locally. Ctrl+b is used as the leader - tmux's default, with no macOS system conflicts (unlike Ctrl+Space which triggers keyboard layout switching).

Keybindings added:
- Leader + " / % - split pane horizontally / vertically
- Leader + h/j/k/l - navigate panes (vim-style)
- Leader + H/J/K/L - resize panes
- Leader + z - zoom / unzoom pane
- Leader + x - close pane (with confirmation prompt)

Also inlines intermediate variables (color_scheme_name, font) directly into config assignments as part of a prior refactor on this branch.