### PR TITLE
feat(vim): add git hunks to quickfix list

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -172,30 +172,7 @@ nnoremap <A-Up> :m<Space>.-2<CR>==
 xnoremap <A-Down> :m<Space>'>+1<CR>gv=gv
 xnoremap <A-Up> :m<Space>'<-2<CR>gv=gv
 " Load git hunks into quickfix list
-function! s:GitHunksToQF() abort
-	let l:lines = systemlist('git diff --no-ext-diff -U0')
-	if v:shell_error
-		echohl ErrorMsg
-		echomsg 'git diff failed'
-		echohl None
-		return
-	endif
-	if empty(l:lines)
-		echomsg 'No git hunks found'
-		return
-	endif
-	call setqflist([], ' ', {
-				\ 'title': 'Git Hunks',
-				\ 'lines': l:lines,
-				\ 'efm':
-				\   '%-Pdiff --git a/%f b/%.%#,'
-				\   . '@@ -%\d%\+%.%# +%l%.%# @@ %m,'
-				\   . '@@ -%\d%\+%.%# +%l%.%# @@,'
-				\   . '%-G%.%#',
-				\ })
-	copen
-endfunction
-nnoremap <leader>gq :call <SID>GitHunksToQF()<CR>
+nnoremap <Leader>gq :call <SID>GitHunksToQF()<CR>
 " Quickfix list navigation
 nnoremap <leader>cc :cclose<CR>
 nnoremap <leader>co :copen<CR>
@@ -319,6 +296,31 @@ endif
 " Re-open last command pre-filled for editing
 function! s:ResumeLastCmd() abort
 	call feedkeys(':' . histget(':'), 'tn')
+endfunction
+
+" Load git hunks into quickfix list
+function! s:GitHunksToQF() abort
+	let l:lines = systemlist('git diff --no-ext-diff -U0')
+	if v:shell_error
+		echohl ErrorMsg
+		echomsg 'git diff failed'
+		echohl None
+		return
+	endif
+	if empty(l:lines)
+		echomsg 'No git hunks found'
+		return
+	endif
+	call setqflist([], ' ', {
+				\ 'title': 'Git Hunks',
+				\ 'lines': l:lines,
+				\ 'efm':
+				\   '%-Pdiff --git a/%f b/%.%#,'
+				\   . '@@ -%\d%\+%.%# +%l%.%# @@ %m,'
+				\   . '@@ -%\d%\+%.%# +%l%.%# @@,'
+				\   . '%-G%.%#',
+				\ })
+	copen
 endfunction
 
 " Set up Git TUI client

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -171,6 +171,39 @@ nnoremap <A-Down> :m<Space>.+1<CR>==
 nnoremap <A-Up> :m<Space>.-2<CR>==
 xnoremap <A-Down> :m<Space>'>+1<CR>gv=gv
 xnoremap <A-Up> :m<Space>'<-2<CR>gv=gv
+" Load git hunks into quickfix list
+function! s:GitHunksToQF() abort
+	let l:output = systemlist(
+				\ 'git diff --no-ext-diff -U0'
+				\ )
+	if v:shell_error
+		echohl ErrorMsg
+		echomsg 'git diff failed'
+		echohl None
+		return
+	endif
+	let l:items = []
+	let l:file = ''
+	for l:line in l:output
+		if l:line =~# '^diff --git'
+			let l:file = matchstr(l:line, 'b/\zs.*')
+		elseif l:line =~# '^@@'
+			let l:lnum = matchstr(l:line, '+\zs\d\+')
+			call add(l:items, {
+						\ 'filename': l:file,
+						\ 'lnum': str2nr(l:lnum),
+						\ 'text': l:line,
+						\ })
+		endif
+	endfor
+	if empty(l:items)
+		echomsg 'No git hunks found'
+		return
+	endif
+	call setqflist([], ' ', {'title': 'Git Hunks', 'items': l:items})
+	copen
+endfunction
+nnoremap <leader>gq :call <SID>GitHunksToQF()<CR>
 " Quickfix list navigation
 nnoremap <leader>cc :cclose<CR>
 nnoremap <leader>co :copen<CR>

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -173,34 +173,26 @@ xnoremap <A-Down> :m<Space>'>+1<CR>gv=gv
 xnoremap <A-Up> :m<Space>'<-2<CR>gv=gv
 " Load git hunks into quickfix list
 function! s:GitHunksToQF() abort
-	let l:output = systemlist(
-				\ 'git diff --no-ext-diff -U0'
-				\ )
+	let l:lines = systemlist('git diff --no-ext-diff -U0')
 	if v:shell_error
 		echohl ErrorMsg
 		echomsg 'git diff failed'
 		echohl None
 		return
 	endif
-	let l:items = []
-	let l:file = ''
-	for l:line in l:output
-		if l:line =~# '^diff --git'
-			let l:file = matchstr(l:line, 'b/\zs.*')
-		elseif l:line =~# '^@@'
-			let l:lnum = matchstr(l:line, '+\zs\d\+')
-			call add(l:items, {
-						\ 'filename': l:file,
-						\ 'lnum': str2nr(l:lnum),
-						\ 'text': l:line,
-						\ })
-		endif
-	endfor
-	if empty(l:items)
+	if empty(l:lines)
 		echomsg 'No git hunks found'
 		return
 	endif
-	call setqflist([], ' ', {'title': 'Git Hunks', 'items': l:items})
+	call setqflist([], ' ', {
+				\ 'title': 'Git Hunks',
+				\ 'lines': l:lines,
+				\ 'efm':
+				\   '%-Pdiff --git a/%f b/%.%#,'
+				\   . '@@ -%\d%\+%.%# +%l%.%# @@ %m,'
+				\   . '@@ -%\d%\+%.%# +%l%.%# @@,'
+				\   . '%-G%.%#',
+				\ })
 	copen
 endfunction
 nnoremap <leader>gq :call <SID>GitHunksToQF()<CR>

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -308,6 +308,8 @@ function! s:GitHunksToQF() abort
 		return
 	endif
 	if empty(l:lines)
+		call setqflist([], ' ', {'title': 'Git Hunks', 'items': []})
+		cclose
 		echomsg 'No git hunks found'
 		return
 	endif


### PR DESCRIPTION
Add `<leader>gq` mapping that runs git diff and populates the quickfix list with hunk locations for navigation via `[q` / `]q`.

Use Vim's built-in `errorformat` parser with `%-P` to capture filenames from diff headers and `%l` for line numbers from `@@` hunk markers, avoiding manual line parsing. 

Clear the quickfix list and close the window when no hunks are found.