### PR TITLE
feat(git): initial config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -34,6 +34,11 @@ Ansible:
           - roles/**/*
           - bootstrap.yml
 
+Git:
+  - changed-files:
+      - any-glob-to-any-file:
+          - git/**/*
+
 Neovim:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,6 +21,7 @@ jobs:
           scopes: |
             alacritty
             ansible
+            git
             neovim
             starship
             task

--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -1,6 +1,14 @@
+[core]
+	pager = delta
+[merge]
+	conflictStyle = zdiff3
 [user]
 	name = Kirill Morozov
 [push]
 	autoSetupRemote = true
 [pull]
 	rebase = true
+[interactive]
+	diffFilter = delta --color-only
+[delta]
+	navigate = true

--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -12,3 +12,7 @@
 	diffFilter = delta --color-only
 [delta]
 	navigate = true
+[credential "https://github.com"]
+	helper = !/opt/homebrew/bin/gh auth git-credential
+[credential "https://gist.github.com"]
+	helper = !/opt/homebrew/bin/gh auth git-credential

--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -1,0 +1,6 @@
+[user]
+	name = Kirill Morozov
+[push]
+	autoSetupRemote = true
+[pull]
+	rebase = true

--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -1,17 +1,19 @@
-[core]
-	pager = delta
+[diff]
+	tool = difftastic
 [merge]
 	conflictStyle = zdiff3
 [user]
 	name = Kirill Morozov
+[pager]
+	difftool = true
 [push]
 	autoSetupRemote = true
 [pull]
 	rebase = true
-[interactive]
-	diffFilter = delta --color-only
-[delta]
-	navigate = true
+[difftool]
+	prompt = false
+[difftool "difftastic"]
+	cmd = difft "$MERGED" "$LOCAL" "abcdef1" "100644" "$REMOTE" "abcdef2" "100644"
 [credential "https://github.com"]
 	helper = !/opt/homebrew/bin/gh auth git-credential
 [credential "https://gist.github.com"]

--- a/roles/development_machine/tasks/install-macos-packages.yml
+++ b/roles/development_machine/tasks/install-macos-packages.yml
@@ -7,6 +7,7 @@
       - eza
       - fd
       - fzf
+      - git-delta
       - glab
       - go-task
       - jq

--- a/roles/development_machine/tasks/install-macos-packages.yml
+++ b/roles/development_machine/tasks/install-macos-packages.yml
@@ -4,10 +4,10 @@
     state: latest
     package:
       - btop
+      - difftastic
       - eza
       - fd
       - fzf
-      - git-delta
       - glab
       - go-task
       - jq

--- a/roles/development_machine/tasks/install-rpm-packages.yml
+++ b/roles/development_machine/tasks/install-rpm-packages.yml
@@ -63,6 +63,7 @@
       - fzf
       - gh
       - git
+      - git-delta
       - glab
       - go-task
       - golang

--- a/roles/development_machine/tasks/install-rpm-packages.yml
+++ b/roles/development_machine/tasks/install-rpm-packages.yml
@@ -58,12 +58,12 @@
     pkg:
       - alacritty
       - btop
+      - difftastic
       - eza
       - fd-find
       - fzf
       - gh
       - git
-      - git-delta
       - glab
       - go-task
       - golang

--- a/roles/development_machine/vars/config-links.yml
+++ b/roles/development_machine/vars/config-links.yml
@@ -2,6 +2,8 @@
 development_machine_directory_mapping:
   - source: "{{ playbook_dir }}/alacritty"
     target: "{{ development_machine_xdg_config_home }}/alacritty"
+  - source: "{{ playbook_dir }}/git"
+    target: "~"
   - source: "{{ playbook_dir }}/neovim"
     target: "{{ development_machine_xdg_config_home }}/nvim"
   - source: "{{ playbook_dir }}/starship"


### PR DESCRIPTION
Track a shared Git configuration in the dotfiles repo and link it into the home directory during development machine setup.

Install difftastic on macOS and RPM-based systems so the configured difftool works out of the box.

Update PR labeling to include a `git` scope for git-related changes.