### PR TITLE
fix(wezterm): set TERM and provision terminfo

### DIFF
--- a/roles/development_machine/tasks/install-packages.yml
+++ b/roles/development_machine/tasks/install-packages.yml
@@ -51,6 +51,19 @@
   tags:
     - packages
     - starship
+- name: Install WezTerm terminfo
+  ansible.builtin.include_tasks:
+    file: install-wezterm-terminfo.yml
+    apply:
+      tags:
+        - packages
+        - terminfo
+        - wezterm
+  when: ansible_facts["system"] == "Linux"
+  tags:
+    - packages
+    - terminfo
+    - wezterm
 - name: Install Oh My Zsh
   ansible.builtin.include_tasks:
     file: install-ohmyzsh.yml

--- a/roles/development_machine/tasks/install-packages.yml
+++ b/roles/development_machine/tasks/install-packages.yml
@@ -59,7 +59,6 @@
         - packages
         - terminfo
         - wezterm
-  when: ansible_facts["system"] == "Linux"
   tags:
     - packages
     - terminfo

--- a/roles/development_machine/tasks/install-wezterm-terminfo.yml
+++ b/roles/development_machine/tasks/install-wezterm-terminfo.yml
@@ -20,6 +20,7 @@
     state: directory
 - name: Compile WezTerm terminfo definition
   when: development_machine_wezterm_terminfo.rc != 0
+  changed_when: development_machine_wezterm_terminfo.rc != 0
   ansible.builtin.command:
     argv:
       - tic

--- a/roles/development_machine/tasks/install-wezterm-terminfo.yml
+++ b/roles/development_machine/tasks/install-wezterm-terminfo.yml
@@ -1,0 +1,33 @@
+---
+- name: Check WezTerm terminfo definition
+  register: development_machine_wezterm_terminfo
+  ansible.builtin.command:
+    cmd: infocmp wezterm
+  changed_when: false
+  failed_when: false
+- name: Download WezTerm terminfo definition
+  when: development_machine_wezterm_terminfo.rc != 0
+  ansible.builtin.get_url:
+    url: https://raw.githubusercontent.com/wezterm/wezterm/main/termwiz/data/wezterm.terminfo
+    dest: /tmp/wezterm.terminfo
+    mode: "0644"
+- name: Ensure user terminfo directory exists
+  when: development_machine_wezterm_terminfo.rc != 0
+  ansible.builtin.file:
+    path: "{{ ansible_env.HOME }}/.terminfo"
+    state: directory
+    mode: "0755"
+- name: Compile WezTerm terminfo definition
+  when: development_machine_wezterm_terminfo.rc != 0
+  ansible.builtin.command:
+    argv:
+      - tic
+      - -x
+      - -o
+      - "{{ ansible_env.HOME }}/.terminfo"
+      - /tmp/wezterm.terminfo
+- name: Remove downloaded WezTerm terminfo definition
+  when: development_machine_wezterm_terminfo.rc != 0
+  ansible.builtin.file:
+    path: /tmp/wezterm.terminfo
+    state: absent

--- a/roles/development_machine/tasks/install-wezterm-terminfo.yml
+++ b/roles/development_machine/tasks/install-wezterm-terminfo.yml
@@ -1,22 +1,23 @@
 ---
 - name: Check WezTerm terminfo definition
+  changed_when: false
+  failed_when: false
   register: development_machine_wezterm_terminfo
   ansible.builtin.command:
     cmd: infocmp wezterm
-  changed_when: false
-  failed_when: false
 - name: Download WezTerm terminfo definition
   when: development_machine_wezterm_terminfo.rc != 0
   ansible.builtin.get_url:
-    url: https://raw.githubusercontent.com/wezterm/wezterm/main/termwiz/data/wezterm.terminfo
     dest: /tmp/wezterm.terminfo
     mode: "0644"
+    url: "https://raw.githubusercontent.com/wezterm/wezterm/main/termwiz/data/\
+      wezterm.terminfo"
 - name: Ensure user terminfo directory exists
   when: development_machine_wezterm_terminfo.rc != 0
   ansible.builtin.file:
+    mode: "0755"
     path: "{{ ansible_env.HOME }}/.terminfo"
     state: directory
-    mode: "0755"
 - name: Compile WezTerm terminfo definition
   when: development_machine_wezterm_terminfo.rc != 0
   ansible.builtin.command:

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -30,6 +30,7 @@ config.enable_scroll_bar = false
 config.font = wezterm.font_with_fallback({ "FiraCode Nerd Font", "Fira Code" })
 config.font_size = 14.0
 config.max_fps = 120
+config.term = "wezterm"
 config.window_padding = { bottom = 0, left = 0, right = 0, top = 0 }
 
 -- Leader key (tmux-style prefix)


### PR DESCRIPTION
Set WezTerm TERM to `wezterm` to match capabilities expected by recent Neovim rendering behaviour.

Add an idempotent Ansible task to install WezTerm terminfo when missing, and include it in the package setup.

Closes: #221