### PR TITLE
feat(neovim): add built-in fuzzy finder and keymaps

### DIFF
--- a/neovim/lua/plugins/fzf.lua
+++ b/neovim/lua/plugins/fzf.lua
@@ -10,7 +10,7 @@ return {
 				"<cmd>vsplit | FzfLua lsp_definitions<CR>",
 				desc = "Go to definition in a split",
 			},
-			{ "gy", "<cmd>FzfLua lsp_typedefs<CR>", desc = "Go to type definition" },
+			{ "grt", "<cmd>FzfLua lsp_typedefs<CR>", desc = "Go to type definition" },
 			{ "grr", "<cmd>FzfLua lsp_references<CR>", desc = "Go to references" },
 			{
 				"gri",

--- a/neovim/lua/plugins/fzf.lua
+++ b/neovim/lua/plugins/fzf.lua
@@ -3,6 +3,7 @@ return {
 	{
 		"ibhagwan/fzf-lua",
 		dependencies = { "echasnovski/mini.nvim", version = "*" },
+		event = "VeryLazy",
 		keys = {
 			{ "gd", "<cmd>FzfLua lsp_definitions<CR>", desc = "Go to definition" },
 			{

--- a/neovim/lua/plugins/fzf.lua
+++ b/neovim/lua/plugins/fzf.lua
@@ -94,5 +94,6 @@ return {
 		},
 		opts = { "max-perf" },
 		version = "*",
+		enabled = false,
 	},
 }

--- a/neovim/lua/plugins/mini.lua
+++ b/neovim/lua/plugins/mini.lua
@@ -10,6 +10,7 @@ return {
 		event = "UIEnter",
 		opts = {
 			cmdline = {
+				autocorrect = { enable = false },
 				autopeek = { enable = false },
 			},
 			completion = {},

--- a/neovim/plugin/finder.lua
+++ b/neovim/plugin/finder.lua
@@ -71,20 +71,3 @@ vim.api.nvim_create_autocmd("CmdlineEnter", {
 		filescache = {}
 	end,
 })
-
--- <C-v> in cmdline: convert :find to :vert sfind, :buffer to :vert sbuffer.
-vim.keymap.set("c", "<C-v>", function()
-	if vim.fn.getcmdtype() ~= ":" then
-		return "<C-v>"
-	end
-	local line = vim.fn.getcmdline()
-	local new_line
-	if line:match("^%s*find%s") then
-		new_line = line:gsub("^(%s*)find%s", "%1vert sfind ", 1)
-	elseif line:match("^%s*buffer%s") then
-		new_line = line:gsub("^(%s*)buffer%s", "%1vert sbuffer ", 1)
-	else
-		return "<C-v>"
-	end
-	return "<C-U>" .. new_line .. "<CR>"
-end, { expr = true, desc = "Open file/buffer in vertical split from cmdline" })

--- a/neovim/plugin/finder.lua
+++ b/neovim/plugin/finder.lua
@@ -1,0 +1,90 @@
+-- Fuzzy file finder using findfunc + matchfuzzy, with wildtrigger autocomplete.
+-- Ported from vim/vimrc.
+
+-- Files cache, cleared on each cmdline entry.
+local filescache = {}
+
+--- Get a list of all files using built-in globpath.
+local function glob_files()
+	local raw = vim.fn.globpath(".", "**", true, true)
+	local files = {}
+	for _, path in ipairs(raw) do
+		if vim.fn.isdirectory(path) == 0 then
+			files[#files + 1] = vim.fn.fnamemodify(path, ":.")
+		end
+	end
+	return files
+end
+
+--- Get a list of all files using fd.
+local function fd_files()
+	local result = vim.fn.systemlist({
+		"fd",
+		"--exclude",
+		".git",
+		"--follow",
+		"--full-path",
+		"--hidden",
+		"--type",
+		"file",
+	})
+	if vim.v.shell_error ~= 0 then
+		vim.api.nvim_err_writeln(table.concat(result, "\n"))
+		return {}
+	end
+	return result
+end
+
+local files_fetcher = vim.fn.executable("fd") == 1 and fd_files or glob_files
+
+--- findfunc: return fuzzy-matched filenames for :find.
+--- Exposed as a global for v:lua access.
+function _G.FindFunc(file)
+	if #filescache == 0 then
+		filescache = files_fetcher()
+	end
+	if file == "" then
+		return filescache
+	end
+	return vim.fn.matchfuzzy(filescache, file)
+end
+
+vim.o.findfunc = "v:lua.FindFunc"
+
+-- Cmdline autocompletion via wildtrigger + cache clearing.
+local finder_group = vim.api.nvim_create_augroup("finder", { clear = true })
+
+vim.api.nvim_create_autocmd("CmdlineChanged", {
+	group = finder_group,
+	pattern = { ":", "/", "?" },
+	desc = "Trigger cmdline autocompletion",
+	callback = function()
+		vim.fn.wildtrigger()
+	end,
+})
+
+vim.api.nvim_create_autocmd("CmdlineEnter", {
+	group = finder_group,
+	pattern = ":",
+	desc = "Clear files cache on cmdline entry",
+	callback = function()
+		filescache = {}
+	end,
+})
+
+-- <C-v> in cmdline: convert :find to :vert sfind, :buffer to :vert sbuffer.
+vim.keymap.set("c", "<C-v>", function()
+	if vim.fn.getcmdtype() ~= ":" then
+		return "<C-v>"
+	end
+	local line = vim.fn.getcmdline()
+	local new_line
+	if line:match("^%s*find%s") then
+		new_line = line:gsub("^(%s*)find%s", "%1vert sfind ", 1)
+	elseif line:match("^%s*buffer%s") then
+		new_line = line:gsub("^(%s*)buffer%s", "%1vert sbuffer ", 1)
+	else
+		return "<C-v>"
+	end
+	return "<C-U>" .. new_line .. "<CR>"
+end, { expr = true, desc = "Open file/buffer in vertical split from cmdline" })

--- a/neovim/plugin/fuzzy.lua
+++ b/neovim/plugin/fuzzy.lua
@@ -1,5 +1,4 @@
--- Fuzzy file finder using findfunc + matchfuzzy, with wildtrigger autocomplete.
--- Ported from vim/vimrc.
+-- Fuzzy finder using findfunc + matchfuzzy, with wildtrigger autocomplete.
 
 -- Files cache, cleared on each cmdline entry.
 local filescache = {}
@@ -52,10 +51,10 @@ end
 vim.o.findfunc = "v:lua.FindFunc"
 
 -- Cmdline autocompletion via wildtrigger + cache clearing.
-local finder_group = vim.api.nvim_create_augroup("finder", { clear = true })
+local fuzzy_group = vim.api.nvim_create_augroup("fuzzy", { clear = true })
 
 vim.api.nvim_create_autocmd("CmdlineChanged", {
-	group = finder_group,
+	group = fuzzy_group,
 	pattern = { ":", "/", "?" },
 	desc = "Trigger cmdline autocompletion",
 	callback = function()
@@ -64,7 +63,7 @@ vim.api.nvim_create_autocmd("CmdlineChanged", {
 })
 
 vim.api.nvim_create_autocmd("CmdlineEnter", {
-	group = finder_group,
+	group = fuzzy_group,
 	pattern = ":",
 	desc = "Clear files cache on cmdline entry",
 	callback = function()

--- a/neovim/plugin/fuzzy.lua
+++ b/neovim/plugin/fuzzy.lua
@@ -51,6 +51,7 @@ end
 vim.o.findfunc = "v:lua.FindFunc"
 
 -- Cmdline autocompletion via wildtrigger + cache clearing.
+-- FIXME(kirill.morozov): create autocommand only if Neovim >= 0.12
 local fuzzy_group = vim.api.nvim_create_augroup("fuzzy", { clear = true })
 
 vim.api.nvim_create_autocmd("CmdlineChanged", {

--- a/neovim/plugin/fuzzy.lua
+++ b/neovim/plugin/fuzzy.lua
@@ -51,7 +51,6 @@ end
 vim.o.findfunc = "v:lua.FindFunc"
 
 -- Cmdline autocompletion via wildtrigger + cache clearing.
--- FIXME(kirill.morozov): create autocommand only if Neovim >= 0.12
 local fuzzy_group = vim.api.nvim_create_augroup("fuzzy", { clear = true })
 
 vim.api.nvim_create_autocmd("CmdlineChanged", {

--- a/neovim/plugin/keymaps.lua
+++ b/neovim/plugin/keymaps.lua
@@ -78,3 +78,12 @@ vim.keymap.set("v", "<A-Up>", ":m '<-2<CR>gv=gv", { desc = "Move selection up" }
 
 -- Open in split
 vim.keymap.set("n", "gsf", "<C-w>vgf", { desc = "Go to file in a split" })
+
+-- Find and buffer navigation
+vim.keymap.set("n", "<leader>f", ":find ", { desc = "Find file" })
+vim.keymap.set("n", "<leader>b", ":buffer ", { desc = "Switch buffer" })
+
+-- Re-open last command pre-filled for editing
+vim.keymap.set("n", "<leader>'", function()
+	vim.fn.feedkeys(":" .. vim.fn.histget(":"), "tn")
+end, { silent = true, desc = "Resume last command" })

--- a/neovim/plugin/keymaps.lua
+++ b/neovim/plugin/keymaps.lua
@@ -69,6 +69,21 @@ vim.keymap.set(
 	vim.lsp.buf.code_action,
 	{ desc = "Select a code action" }
 )
+vim.keymap.set("n", "gsd", function()
+	vim.cmd.vsplit()
+	vim.lsp.buf.definition()
+end, { desc = "Go to definition in a split" })
+vim.keymap.set("n", "<leader>s", function()
+	if next(vim.lsp.get_clients({ bufnr = 0 })) then
+		vim.lsp.buf.document_symbol()
+	end
+end, { desc = "Document symbols" })
+vim.keymap.set(
+	"n",
+	"<leader>S",
+	vim.lsp.buf.workspace_symbol,
+	{ desc = "Workspace symbols" }
+)
 
 -- Move text up and down
 vim.keymap.set("n", "<A-Down>", ":m .+1<CR>==", { desc = "Move line down" })
@@ -79,11 +94,24 @@ vim.keymap.set("v", "<A-Up>", ":m '<-2<CR>gv=gv", { desc = "Move selection up" }
 -- Open in split
 vim.keymap.set("n", "gsf", "<C-w>vgf", { desc = "Go to file in a split" })
 
+-- Search
+vim.keymap.set("n", "<Leader>/", ":grep ", { desc = "Grep" })
+
 -- Find and buffer navigation
-vim.keymap.set("n", "<leader>f", ":find ", { desc = "Find file" })
-vim.keymap.set("n", "<leader>b", ":buffer ", { desc = "Switch buffer" })
+vim.keymap.set("n", "<Leader>f", ":find ", { desc = "Find file" })
+vim.keymap.set("n", "<Leader>b", ":buffer ", { desc = "Switch buffer" })
+vim.keymap.set("n", "<Leader>h", ":vert help ", { desc = "Help" })
+vim.keymap.set("n", "<Leader>j", vim.cmd.jumps, { desc = "List jumps" })
+
+-- Diagnostics
+vim.keymap.set("n", "<Leader>d", function()
+	vim.diagnostic.setloclist({ open = true })
+end, { desc = "Document diagnostics" })
+vim.keymap.set("n", "<Leader>D", function()
+	vim.diagnostic.setqflist({ open = true })
+end, { desc = "Workspace diagnostics" })
 
 -- Re-open last command pre-filled for editing
-vim.keymap.set("n", "<leader>'", function()
+vim.keymap.set("n", "<Leader>'", function()
 	vim.fn.feedkeys(":" .. vim.fn.histget(":"), "tn")
 end, { silent = true, desc = "Resume last command" })

--- a/neovim/plugin/keymaps.lua
+++ b/neovim/plugin/keymaps.lua
@@ -100,7 +100,7 @@ vim.keymap.set("n", "<Leader>/", ":grep ", { desc = "Grep" })
 -- Find and buffer navigation
 vim.keymap.set("n", "<Leader>f", ":find ", { desc = "Find file" })
 vim.keymap.set("n", "<Leader>b", ":buffer ", { desc = "Switch buffer" })
-vim.keymap.set("n", "<Leader>h", ":vert help ", { desc = "Help" })
+vim.keymap.set("n", "<Leader>h", ":help ", { desc = "Help" })
 vim.keymap.set("n", "<Leader>j", vim.cmd.jumps, { desc = "List jumps" })
 
 -- Diagnostics
@@ -110,6 +110,28 @@ end, { desc = "Document diagnostics" })
 vim.keymap.set("n", "<Leader>D", function()
 	vim.diagnostic.setqflist({ open = true })
 end, { desc = "Workspace diagnostics" })
+
+-- <C-v> in cmdline: open :find, :buffer, :help in a vertical split.
+local vert_replacements = {
+	find = "vert sfind",
+	buffer = "vert sbuffer",
+	help = "vert help",
+}
+
+vim.keymap.set("c", "<C-v>", function()
+	if vim.fn.getcmdtype() ~= ":" then
+		return "<C-v>"
+	end
+	local line = vim.fn.getcmdline()
+	for cmd, vert_cmd in pairs(vert_replacements) do
+		if line:match("^%s*" .. cmd .. "%s") then
+			local new_line =
+				line:gsub("^(%s*)" .. cmd .. "%s", "%1" .. vert_cmd .. " ", 1)
+			return "<C-U>" .. new_line .. "<CR>"
+		end
+	end
+	return "<C-v>"
+end, { expr = true, desc = "Open in vertical split from cmdline" })
 
 -- Re-open last command pre-filled for editing
 vim.keymap.set("n", "<Leader>'", function()

--- a/neovim/plugin/keymaps.lua
+++ b/neovim/plugin/keymaps.lua
@@ -69,6 +69,7 @@ vim.keymap.set(
 	vim.lsp.buf.code_action,
 	{ desc = "Select a code action" }
 )
+vim.keymap.set("n", "gd", vim.lsp.buf.definition, { desc = "Go to definition" })
 vim.keymap.set("n", "gsd", function()
 	vim.cmd.vsplit()
 	vim.lsp.buf.definition()
@@ -102,6 +103,7 @@ vim.keymap.set("n", "<Leader>f", ":find ", { desc = "Find file" })
 vim.keymap.set("n", "<Leader>b", ":buffer ", { desc = "Switch buffer" })
 vim.keymap.set("n", "<Leader>h", ":help ", { desc = "Help" })
 vim.keymap.set("n", "<Leader>j", vim.cmd.jumps, { desc = "List jumps" })
+vim.keymap.set("n", "<Leader>?", "q:", { desc = "Command-line window" })
 
 -- Diagnostics
 vim.keymap.set("n", "<Leader>d", function()

--- a/neovim/plugin/options.lua
+++ b/neovim/plugin/options.lua
@@ -74,7 +74,7 @@ vim.opt.wildmode = { "noselect:lastused", "full" }
 -- Use popup menu for command-line completion
 vim.opt.wildoptions = "pum"
 -- Limit the height of a popup menu
-vim.opt.pumheight = 10
+vim.opt.pumheight = 20
 -- Hide noise in completion
 vim.opt.wildignore:append({ "*.pyc", "*/.git/*", "*/node_modules/*" })
 


### PR DESCRIPTION
Port cmdline autocompletion from vim/vimrc to Neovim:
- Fuzzy file finder via `findfunc` + `matchfuzzy` with `fd`/`globpath`
- Automatic cmdline popup via `wildtrigger`
- Built-in keymaps for LSP, grep, find, buffer, help, diagnostics
- `<C-v>` in cmdline to open `:find`/`:buffer`/`:help` in vertical split
- `<Leader>'` to resume last command

These serve as defaults that fzf-lua overrides when enabled via VeryLazy loading, keeping plugin/keymaps.lua plugin-agnostic.

Requires Neovim >= 0.12 to work properly.