### PR TITLE
feat(vim): sort json keys

### DIFF
--- a/vim/ftplugin/json.vim
+++ b/vim/ftplugin/json.vim
@@ -1,2 +1,2 @@
 compiler jq
-setlocal formatprg=jq\ '.'
+setlocal formatprg=jq\ -S\ '.'


### PR DESCRIPTION
Add `-S` flag to jq formatprg call to keep json keys sorted.