### PR TITLE
feat(wezterm): add editor/agent split key binding

### DIFF
--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -64,6 +64,16 @@ config.keys = {
 		key = "Enter",
 		mods = "LEADER",
 		action = wezterm.action_callback(function(window, pane)
+			local editor = os.getenv("EDITOR")
+			local agent = os.getenv("AGENT")
+			if not editor then
+				wezterm.log_error("EDITOR environment variable is not set")
+				return
+			end
+			if not agent then
+				wezterm.log_error("AGENT environment variable is not set")
+				return
+			end
 			-- Split right with a smaller pane for agent, keep current pane
 			-- larger for editor.
 			local ok, agent_pane = pcall(function()
@@ -79,8 +89,8 @@ config.keys = {
 				)
 				return
 			end
-			window:perform_action(wezterm.action.SendString("vim\n"), pane)
-			window:perform_action(wezterm.action.SendString("codex\n"), agent_pane)
+			window:perform_action(wezterm.action.SendString(editor .. "\n"), pane)
+			window:perform_action(wezterm.action.SendString(agent .. "\n"), agent_pane)
 		end),
 	},
 

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -79,7 +79,7 @@ config.keys = {
 				)
 				return
 			end
-			window:perform_action(wezterm.action.SendString("vimx\n"), pane)
+			window:perform_action(wezterm.action.SendString("vim\n"), pane)
 			window:perform_action(wezterm.action.SendString("codex\n"), agent_pane)
 		end),
 	},

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -79,9 +79,10 @@ config.keys = {
 				)
 				return
 			end
-			-- Let the shell expand $EDITOR and $AGENT — WezTerm's Lua
-			-- process doesn't inherit shell environment variables on macOS.
-			-- ${VAR:?msg} makes the shell print an error if unset/empty.
+			-- NOTE(kirill.morozov): Let the shell expand `$EDITOR` and
+			-- `$AGENT` because looking them up using `os.getenv` in WezTerm's
+			-- Lua returns nothing. ${VAR:?msg} makes the shell print an error
+			-- if unset/empty.
 			window:perform_action(
 				wezterm.action.SendString("${EDITOR:?EDITOR is not set}\n"),
 				pane

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -24,6 +24,25 @@ end
 local config = wezterm.config_builder()
 config:set_strict_mode(true)
 
+local split_nvim_codex = wezterm.action_callback(function(window, pane)
+	-- Split right with a smaller pane for codex, keep current pane larger for
+	-- nvim.
+	local ok, codex_pane = pcall(function()
+		return pane:split({
+			direction = "Right",
+			size = 0.33,
+		})
+	end)
+	if not ok then
+		wezterm.log_error(
+			"Failed to split pane for nvim/codex layout: " .. tostring(codex_pane)
+		)
+		return
+	end
+	window:perform_action(wezterm.action.SendString("nvim\n"), pane)
+	window:perform_action(wezterm.action.SendString("codex\n"), codex_pane)
+end)
+
 config.animation_fps = 120
 config.color_scheme = scheme_for_appearance(get_appearance())
 config.enable_scroll_bar = false
@@ -59,6 +78,11 @@ config.keys = {
 		key = "%",
 		mods = "LEADER|SHIFT",
 		action = wezterm.action.SplitHorizontal({ domain = "CurrentPaneDomain" }),
+	},
+	{
+		key = "Enter",
+		mods = "LEADER",
+		action = split_nvim_codex,
 	},
 
 	-- Navigate panes (vim-style, popular tmux plugin: vim-tmux-navigator)

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -64,16 +64,6 @@ config.keys = {
 		key = "Enter",
 		mods = "LEADER",
 		action = wezterm.action_callback(function(window, pane)
-			local editor = os.getenv("EDITOR")
-			local agent = os.getenv("AGENT")
-			if not editor then
-				wezterm.log_error("EDITOR environment variable is not set")
-				return
-			end
-			if not agent then
-				wezterm.log_error("AGENT environment variable is not set")
-				return
-			end
 			-- Split right with a smaller pane for agent, keep current pane
 			-- larger for editor.
 			local ok, agent_pane = pcall(function()
@@ -89,8 +79,17 @@ config.keys = {
 				)
 				return
 			end
-			window:perform_action(wezterm.action.SendString(editor .. "\n"), pane)
-			window:perform_action(wezterm.action.SendString(agent .. "\n"), agent_pane)
+			-- Let the shell expand $EDITOR and $AGENT — WezTerm's Lua
+			-- process doesn't inherit shell environment variables on macOS.
+			-- ${VAR:?msg} makes the shell print an error if unset/empty.
+			window:perform_action(
+				wezterm.action.SendString("${EDITOR:?EDITOR is not set}\n"),
+				pane
+			)
+			window:perform_action(
+				wezterm.action.SendString("${AGENT:?AGENT is not set}\n"),
+				agent_pane
+			)
 		end),
 	},
 

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -24,25 +24,6 @@ end
 local config = wezterm.config_builder()
 config:set_strict_mode(true)
 
-local split_nvim_codex = wezterm.action_callback(function(window, pane)
-	-- Split right with a smaller pane for codex, keep current pane larger for
-	-- nvim.
-	local ok, codex_pane = pcall(function()
-		return pane:split({
-			direction = "Right",
-			size = 0.33,
-		})
-	end)
-	if not ok then
-		wezterm.log_error(
-			"Failed to split pane for nvim/codex layout: " .. tostring(codex_pane)
-		)
-		return
-	end
-	window:perform_action(wezterm.action.SendString("nvim\n"), pane)
-	window:perform_action(wezterm.action.SendString("codex\n"), codex_pane)
-end)
-
 config.animation_fps = 120
 config.color_scheme = scheme_for_appearance(get_appearance())
 config.enable_scroll_bar = false
@@ -82,7 +63,25 @@ config.keys = {
 	{
 		key = "Enter",
 		mods = "LEADER",
-		action = split_nvim_codex,
+		action = wezterm.action_callback(function(window, pane)
+			-- Split right with a smaller pane for agent, keep current pane
+			-- larger for editor.
+			local ok, agent_pane = pcall(function()
+				return pane:split({
+					direction = "Right",
+					size = 0.33,
+				})
+			end)
+			if not ok then
+				wezterm.log_error(
+					"Failed to split pane for editor/agent layout: "
+						.. tostring(agent_pane)
+				)
+				return
+			end
+			window:perform_action(wezterm.action.SendString("vimx\n"), pane)
+			window:perform_action(wezterm.action.SendString("codex\n"), agent_pane)
+		end),
 	},
 
 	-- Navigate panes (vim-style, popular tmux plugin: vim-tmux-navigator)

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -44,7 +44,11 @@ source $ZSH/oh-my-zsh.sh
 
 # User configuration
 export BAT_THEME="base16"
-export EDITOR='vim'
+if command -v vimx &> /dev/null; then
+  export EDITOR="$(command -v vimx)"
+else
+  export EDITOR="$(command -v vim)"
+fi
 if command -v claude &> /dev/null; then
   export AGENT='claude'
 elif command -v codex &> /dev/null; then

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -95,6 +95,9 @@ fi
 if command -v go-task &> /dev/null; then
   alias task="go-task"
 fi
+if command -v vimx &> /dev/null; then
+  alias vim='vimx'
+fi
 alias da='switch_to_dark_mode'
 alias e='eza -l --total-size --time-style long-iso --group-directories-first --icons'
 alias ea='e -a'

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -45,6 +45,11 @@ source $ZSH/oh-my-zsh.sh
 # User configuration
 export BAT_THEME="base16"
 export EDITOR='vim'
+if command -v claude &> /dev/null; then
+  export AGENT='claude'
+elif command -v codex &> /dev/null; then
+  export AGENT='codex'
+fi
 export MANPAGER="vim +MANPAGER --not-a-term -"
 export STARSHIP_CONFIG=${XDG_CONFIG_HOME:-$HOME/.config}/starship/starship.toml
 


### PR DESCRIPTION
Add a `LEADER+Enter` action that opens a right-side pane and starts `${EDITOR}` in the current pane and `${AGENT}` in the new pane.

Set `EDITOR` and `AGENT` in zsh so the shortcut works from shell env, and resolve `EDITOR` to a concrete executable path (prefer `vimx`, fallback `vim`) to avoid alias-expansion failures.