### PR TITLE
fix(neovim): fzf crashing on references lookup

### DIFF
--- a/neovim/lua/plugins/fzf.lua
+++ b/neovim/lua/plugins/fzf.lua
@@ -91,7 +91,7 @@ return {
 				desc = "Quickfix list",
 			},
 		},
-		opts = { "fzf-vim" },
+		opts = { "max-perf" },
 		version = "*",
 	},
 }


### PR DESCRIPTION
Use max-perf profile that disables some of the functionality that leads to crashes.

It also helps a bit with performance.